### PR TITLE
feat: add support for compounds, quirks, and implementations

### DIFF
--- a/examples/advanced/quirks.fn
+++ b/examples/advanced/quirks.fn
@@ -1,0 +1,26 @@
+imp std.io;
+
+compound Point {
+  num x;
+  num y;
+}
+
+quirk HasX {
+  getX() num;
+}
+
+impl Point HasX {
+  getX() num {
+    ret self.x;
+  }
+}
+
+fun main() {
+  Point p;
+  p.x = 41;
+  p.y = 1;
+
+  HasX hx = &p;
+  num v = hx.getX();
+  printf("getX=%d\n", v);
+}

--- a/modules/ast/ast.zig
+++ b/modules/ast/ast.zig
@@ -66,6 +66,12 @@ pub const NodeType = enum {
     Bracket,
     /// Represents an import node.
     Import,
+    /// Represents a user-defined compound type declaration.
+    Compound,
+    /// Represents a quirk (structural interface) declaration.
+    Quirk,
+    /// Represents an implementation block binding a compound type to a quirk.
+    Impl,
     /// Represents a blank node.
     Blank,
 };
@@ -169,6 +175,22 @@ pub const Node = struct {
             /// The body of the function.
             body: ?*Node = null,
         },
+
+        compound: struct {
+            name: std.ArrayList(u8),
+            fields: utils.Vector(CompoundField),
+        },
+
+        quirk: struct {
+            name: std.ArrayList(u8),
+            methods: utils.Vector(QuirkMethodSig),
+        },
+
+        impl: struct {
+            type_name: std.ArrayList(u8),
+            quirk_name: std.ArrayList(u8),
+            methods: utils.Vector(*Node),
+        },
         /// The statement node.
         statement: union(enum) {
             /// The return statement node.
@@ -219,6 +241,22 @@ pub const Node = struct {
             },
         },
     } = null,
+};
+
+pub const CompoundField = struct {
+    name: std.ArrayList(u8),
+    dtype: *dtype.DataType,
+};
+
+pub const QuirkMethodSig = struct {
+    name: std.ArrayList(u8),
+    rtype: dtype.DataType,
+    args: utils.Vector(QuirkArg),
+};
+
+pub const QuirkArg = struct {
+    name: std.ArrayList(u8),
+    dtype: *dtype.DataType,
 };
 
 /// Represents the branches in a fit statement.

--- a/modules/codegen/transpiler.zig
+++ b/modules/codegen/transpiler.zig
@@ -79,6 +79,49 @@ pub const GlobalSymbolInfo = struct {
     is_function: bool,
 };
 
+pub const TypeRegistry = struct {
+    allocator: mem.Allocator,
+
+    /// Maps `compound` names to their defining heap node.
+    compounds_by_name: std.StringHashMap(*ast.Node),
+
+    /// Maps quirk names to a canonical signature key.
+    quirk_sig_by_name: std.StringHashMap([]const u8),
+
+    /// Maps canonical signature key to the (first-seen) quirk definition node.
+    quirks_by_sig: std.StringHashMap(*ast.Node),
+
+    /// Maps `<Type>|<QuirkSig>` to the impl definition node.
+    impls_by_key: std.StringHashMap(*ast.Node),
+
+    /// Owned allocations for quirk signature keys and impl keys.
+    owned_keys: std.ArrayList([]const u8),
+
+    pub fn init(allocator: mem.Allocator) TypeRegistry {
+        return .{
+            .allocator = allocator,
+            .compounds_by_name = std.StringHashMap(*ast.Node).init(allocator),
+            .quirk_sig_by_name = std.StringHashMap([]const u8).init(allocator),
+            .quirks_by_sig = std.StringHashMap(*ast.Node).init(allocator),
+            .impls_by_key = std.StringHashMap(*ast.Node).init(allocator),
+            .owned_keys = std.ArrayList([]const u8).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *TypeRegistry) void {
+        // compound/quirk name keys are borrowed from AST node allocations.
+        self.compounds_by_name.deinit();
+        self.quirk_sig_by_name.deinit();
+        self.quirks_by_sig.deinit();
+        self.impls_by_key.deinit();
+
+        for (self.owned_keys.items) |k| {
+            self.allocator.free(k);
+        }
+        self.owned_keys.deinit();
+    }
+};
+
 /// `TranspileProcess` represents the state and configuration of a transpilation process.
 pub const TranspileProcess = struct {
     /// `flags` is a set of flags that control the behavior of the transpilation process.
@@ -106,6 +149,9 @@ pub const TranspileProcess = struct {
 
     /// Heap-allocated scope entities created by the parser.
     owned_scope_entities: std.ArrayList(*scope.ScopeEntity),
+
+    /// Guard to avoid emitting type/vtable prelude more than once.
+    did_emit_user_types: bool = false,
     /// Track if we're currently transpiling function parameters
     in_function_params: bool = false,
     /// Current indentation level for code formatting
@@ -153,6 +199,10 @@ pub const TranspileProcess = struct {
     /// Track global symbols across all modules to detect duplicates
     global_symbols: std.StringHashMap(GlobalSymbolInfo),
 
+    /// Registry for user-defined types (`compound`/`quirk`/`impl`).
+    /// Stored only on the root process; children access it through `get_root()`.
+    type_registry: ?TypeRegistry = null,
+
     /// Parent TranspileProcess if this is a child import process
     parent: ?*TranspileProcess = null,
 
@@ -172,6 +222,198 @@ pub const TranspileProcess = struct {
     current_token: ?token.Token = null,
 
     const Self = @This();
+
+    fn get_root(self: *Self) *Self {
+        var cur: *Self = self;
+        while (cur.parent) |p| {
+            cur = p;
+        }
+        return cur;
+    }
+
+    fn ensure_type_registry(self: *Self) *TypeRegistry {
+        const root = self.get_root();
+        if (root.type_registry == null) {
+            root.type_registry = TypeRegistry.init(root.allocator);
+        }
+        return &root.type_registry.?;
+    }
+
+    fn append_dtype_sig(self: *Self, buf: *std.ArrayList(u8), dt: *const dtype.DataType) TranspileError!void {
+        _ = self;
+        buf.appendSlice(dt.type_str.items) catch {
+            return TranspileError.MemoryAllocationFailed;
+        };
+        if (dt.pointer_depth > 0) {
+            var i: usize = 0;
+            while (i < dt.pointer_depth) : (i += 1) {
+                buf.append('*') catch {
+                    return TranspileError.MemoryAllocationFailed;
+                };
+            }
+        }
+        if (dt.array) |arr| {
+            var i: usize = 0;
+            while (i < arr.brackets.count) : (i += 1) {
+                buf.appendSlice("[]") catch {
+                    return TranspileError.MemoryAllocationFailed;
+                };
+            }
+        }
+    }
+
+    fn quirk_signature_key(self: *Self, qnode: *ast.Node) TranspileError![]const u8 {
+        if (qnode.node_variant == null) return TranspileError.UnsupportedNodeType;
+        const q = qnode.node_variant.?.quirk;
+
+        var buf = std.ArrayList(u8).init(self.allocator);
+        defer buf.deinit();
+
+        const methods = q.methods.items();
+        var idxs = self.allocator.alloc(usize, methods.len) catch {
+            return TranspileError.MemoryAllocationFailed;
+        };
+        defer self.allocator.free(idxs);
+        for (methods, 0..) |_, i| idxs[i] = i;
+
+        // Structural equivalence should not depend on declaration order.
+        std.sort.pdq(usize, idxs, methods, struct {
+            fn lessThan(ctx: []const ast.QuirkMethodSig, a: usize, b: usize) bool {
+                return mem.lessThan(u8, ctx[a].name.items, ctx[b].name.items);
+            }
+        }.lessThan);
+
+        for (idxs) |mi| {
+            const m = methods[mi];
+
+            buf.appendSlice(m.name.items) catch {
+                return TranspileError.MemoryAllocationFailed;
+            };
+            buf.append('(') catch {
+                return TranspileError.MemoryAllocationFailed;
+            };
+
+            const args = m.args.items();
+            for (args, 0..) |a, ai| {
+                if (ai != 0) {
+                    buf.appendSlice(",") catch {
+                        return TranspileError.MemoryAllocationFailed;
+                    };
+                }
+                try self.append_dtype_sig(&buf, a.dtype);
+            }
+
+            buf.appendSlice(")->") catch {
+                return TranspileError.MemoryAllocationFailed;
+            };
+            try self.append_dtype_sig(&buf, &m.rtype);
+            buf.append(';') catch {
+                return TranspileError.MemoryAllocationFailed;
+            };
+        }
+
+        const owned = buf.toOwnedSlice() catch {
+            return TranspileError.MemoryAllocationFailed;
+        };
+        return owned;
+    }
+
+    fn collect_type_registry_module(self: *Self, proc: *Self, reg: *TypeRegistry) TranspileError!void {
+        for (proc.owned_nodes.items) |n| {
+            switch (n.type) {
+                .Compound => {
+                    if (n.node_variant == null) continue;
+                    const name = n.node_variant.?.compound.name.items;
+                    if (reg.compounds_by_name.contains(name)) {
+                        return TranspileError.DuplicateSymbol;
+                    }
+                    reg.compounds_by_name.put(name, n) catch {
+                        return TranspileError.MemoryAllocationFailed;
+                    };
+                },
+                .Quirk => {
+                    if (n.node_variant == null) continue;
+                    const name = n.node_variant.?.quirk.name.items;
+
+                    const sig_key = try self.quirk_signature_key(n);
+                    reg.owned_keys.append(sig_key) catch {
+                        self.allocator.free(sig_key);
+                        return TranspileError.MemoryAllocationFailed;
+                    };
+
+                    // Register canonical quirk by signature (first one wins).
+                    if (!reg.quirks_by_sig.contains(sig_key)) {
+                        reg.quirks_by_sig.put(sig_key, n) catch {
+                            return TranspileError.MemoryAllocationFailed;
+                        };
+                    }
+
+                    // Map name -> signature.
+                    if (reg.quirk_sig_by_name.contains(name)) {
+                        return TranspileError.DuplicateSymbol;
+                    }
+                    reg.quirk_sig_by_name.put(name, sig_key) catch {
+                        return TranspileError.MemoryAllocationFailed;
+                    };
+                },
+                .Impl => {
+                    // Collected in a second pass after all quirks are known.
+                },
+                else => {},
+            }
+        }
+    }
+
+    fn collect_impls_module(self: *Self, proc: *Self, reg: *TypeRegistry) TranspileError!void {
+        for (proc.owned_nodes.items) |n| {
+            if (n.type != .Impl or n.node_variant == null) continue;
+            const imp = n.node_variant.?.impl;
+            const type_name = imp.type_name.items;
+            const quirk_name = imp.quirk_name.items;
+
+            const sig = reg.quirk_sig_by_name.get(quirk_name) orelse quirk_name;
+
+            const key_len = type_name.len + 1 + sig.len;
+            var key_buf = self.allocator.alloc(u8, key_len) catch {
+                return TranspileError.MemoryAllocationFailed;
+            };
+            errdefer self.allocator.free(key_buf);
+            @memcpy(key_buf[0..type_name.len], type_name);
+            key_buf[type_name.len] = '|';
+            @memcpy(key_buf[type_name.len + 1 ..], sig);
+
+            if (reg.impls_by_key.contains(key_buf)) {
+                return TranspileError.DuplicateSymbol;
+            }
+
+            reg.impls_by_key.put(key_buf, n) catch {
+                return TranspileError.MemoryAllocationFailed;
+            };
+            reg.owned_keys.append(key_buf) catch {
+                return TranspileError.MemoryAllocationFailed;
+            };
+        }
+    }
+
+    fn collect_type_registry_all(self: *Self) TranspileError!void {
+        const reg = self.ensure_type_registry();
+
+        // Rebuild from scratch each transpile run.
+        reg.deinit();
+        self.get_root().type_registry = TypeRegistry.init(self.get_root().allocator);
+        const new_reg = &self.get_root().type_registry.?;
+
+        try self.collect_type_registry_module(self, new_reg);
+        for (self.children.items) |child| {
+            try self.collect_type_registry_module(child, new_reg);
+        }
+
+        // Second pass: impls need quirk name->signature resolution.
+        try self.collect_impls_module(self, new_reg);
+        for (self.children.items) |child| {
+            try self.collect_impls_module(child, new_reg);
+        }
+    }
 
     fn build_full_import_path(self: *Self, import_path: []const u8) TranspileError![]const u8 {
         var file_path = std.ArrayList(u8).init(self.allocator);
@@ -506,9 +748,16 @@ pub const TranspileProcess = struct {
         base: dtype.DataTypeType,
         is_array: bool = false,
         pointer_depth: usize = 0,
+        /// For user-defined types, `base` is `.Unknown` and `name` holds the identifier.
+        name: ?[]const u8 = null,
 
         fn eql(a: CheckedType, b: CheckedType) bool {
-            return a.base == b.base and a.is_array == b.is_array and a.pointer_depth == b.pointer_depth;
+            if (a.base != b.base) return false;
+            if (a.is_array != b.is_array) return false;
+            if (a.pointer_depth != b.pointer_depth) return false;
+            if (a.name == null and b.name == null) return true;
+            if (a.name == null or b.name == null) return false;
+            return mem.eql(u8, a.name.?, b.name.?);
         }
     };
 
@@ -590,7 +839,44 @@ pub const TranspileProcess = struct {
             .base = base,
             .is_array = (dt.flags != null and dt.flags.?.is_array),
             .pointer_depth = dt.pointer_depth,
+            .name = if (base == .Unknown and dt.type_str.items.len > 0) dt.type_str.items else null,
         };
+    }
+
+    fn is_known_type(t: CheckedType) bool {
+        return t.base != .Unknown or t.name != null;
+    }
+
+    fn is_user_named_type(t: CheckedType) bool {
+        return t.base == .Unknown and t.name != null;
+    }
+
+    fn lookup_compound_field(self: *Self, compound_name: []const u8, field_name: []const u8) ?*const dtype.DataType {
+        const root = self.get_root();
+        if (root.type_registry == null) return null;
+        const reg = &root.type_registry.?;
+        const cnode = reg.compounds_by_name.get(compound_name) orelse return null;
+        if (cnode.node_variant == null) return null;
+        const fields = cnode.node_variant.?.compound.fields.items();
+        for (fields) |f| {
+            if (mem.eql(u8, f.name.items, field_name)) return f.dtype;
+        }
+        return null;
+    }
+
+    fn lookup_quirk_method(self: *Self, quirk_name: []const u8, method_name: []const u8) ?ast.QuirkMethodSig {
+        const root = self.get_root();
+        if (root.type_registry == null) return null;
+        const reg = &root.type_registry.?;
+
+        const sig = reg.quirk_sig_by_name.get(quirk_name) orelse return null;
+        const qnode = reg.quirks_by_sig.get(sig) orelse return null;
+        if (qnode.node_variant == null) return null;
+        const methods = qnode.node_variant.?.quirk.methods.items();
+        for (methods) |m| {
+            if (mem.eql(u8, m.name.items, method_name)) return m;
+        }
+        return null;
     }
 
     fn is_numeric_type(t: CheckedType) bool {
@@ -603,8 +889,29 @@ pub const TranspileProcess = struct {
         return .Num;
     }
 
-    fn can_implicit_coerce(expected: CheckedType, actual: CheckedType) bool {
+    fn is_quirk_named_type(self: *Self, t: CheckedType) bool {
+        if (!is_user_named_type(t)) return false;
+        const root = self.get_root();
+        if (root.type_registry == null) return false;
+        return root.type_registry.?.quirk_sig_by_name.contains(t.name.?);
+    }
+
+    fn can_implicit_coerce(self: *Self, expected: CheckedType, actual: CheckedType) TranspileError!bool {
         if (CheckedType.eql(expected, actual)) return true;
+
+        // Quirk coercion: allow `T*` -> `Quirk` if an `impl T Quirk { ... }` exists.
+        if (self.is_quirk_named_type(expected) and is_user_named_type(actual) and actual.pointer_depth == 1 and !actual.is_array) {
+            const root = self.get_root();
+            if (root.type_registry == null) return false;
+            const reg = &root.type_registry.?;
+            const sig = reg.quirk_sig_by_name.get(expected.name.?) orelse return false;
+            const key = std.fmt.allocPrint(self.allocator, "{s}|{s}", .{ actual.name.?, sig }) catch {
+                return TranspileError.MemoryAllocationFailed;
+            };
+            defer self.allocator.free(key);
+            if (reg.impls_by_key.contains(key)) return true;
+        }
+
         if (expected.is_array != actual.is_array or expected.pointer_depth != actual.pointer_depth) return false;
 
         // Allow widening conversions.
@@ -698,6 +1005,25 @@ pub const TranspileProcess = struct {
             .Unary => {
                 const u = node.node_variant.?.unary;
                 const operand_t = try self.infer_expr_type(u.operand.*, env, fns);
+
+                // Indirection unary: `*x`, `**x`, ...
+                if (u.indirection) |ind| {
+                    if (operand_t.pointer_depth < ind.depth) {
+                        self.report_type_error(node, "cannot dereference a non-pointer", .{});
+                        return TranspileError.TypeMismatch;
+                    }
+                    var out = operand_t;
+                    out.pointer_depth -= ind.depth;
+                    return out;
+                }
+
+                // Address-of: `&x`
+                if (mem.eql(u8, u.op, "&")) {
+                    var out = operand_t;
+                    out.pointer_depth += 1;
+                    return out;
+                }
+
                 if (mem.eql(u8, u.op, "!")) {
                     if (operand_t.base != .Bin) {
                         self.report_type_error(node, "unary '!' expects bin operand", .{});
@@ -747,16 +1073,53 @@ pub const TranspileProcess = struct {
                         return TranspileError.NotCallable;
                     };
 
-                    if (callee.type != .Identifier or callee.data == null) {
-                        self.report_type_error(node, "only calling named functions is supported", .{});
+                    // Standard function call: `foo(...)`.
+                    var maybe_sig: ?FnSig = null;
+                    var call_rtype: CheckedType = .{ .base = .Unknown };
+                    var method_sig: ?ast.QuirkMethodSig = null;
+
+                    if (callee.type == .Identifier and callee.data != null) {
+                        const fname = callee.data.?.sval.items;
+                        if (fns.get(fname)) |sig| {
+                            maybe_sig = sig;
+                            call_rtype = sig.rtype;
+                        } else {
+                            // External/stdlib function (e.g. printf). Skip type checking.
+                            return .{ .base = .Unknown };
+                        }
+                    } else if (callee.type == .Expression and callee.node_variant != null and mem.eql(u8, callee.node_variant.?.exp.op, ".")) {
+                        // Quirk method call: `q.method(...)`.
+                        const dot = callee.node_variant.?.exp;
+                        const recv = dot.left orelse {
+                            self.report_type_error(node, "invalid method call", .{});
+                            return TranspileError.NotCallable;
+                        };
+                        const member = dot.right orelse {
+                            self.report_type_error(node, "invalid method call", .{});
+                            return TranspileError.NotCallable;
+                        };
+                        if (member.type != .Identifier or member.data == null) {
+                            self.report_type_error(node, "invalid method call", .{});
+                            return TranspileError.NotCallable;
+                        }
+
+                        const recv_t = try self.infer_expr_type(recv.*, env, fns);
+                        if (!is_user_named_type(recv_t)) {
+                            self.report_type_error(node, "method calls require a quirk-typed receiver", .{});
+                            return TranspileError.NotCallable;
+                        }
+
+                        const mname = member.data.?.sval.items;
+                        method_sig = self.lookup_quirk_method(recv_t.name.?, mname) orelse {
+                            self.report_type_error(node, "quirk '{s}' has no method '{s}'", .{ recv_t.name.?, mname });
+                            return TranspileError.NotCallable;
+                        };
+
+                        call_rtype = type_from_dtype(&method_sig.?.rtype);
+                    } else {
+                        self.report_type_error(node, "only calling named functions or quirk methods is supported", .{});
                         return TranspileError.NotCallable;
                     }
-
-                    const fname = callee.data.?.sval.items;
-                    const sig = fns.get(fname) orelse {
-                        // External/stdlib function (e.g. printf). Skip type checking.
-                        return .{ .base = .Unknown };
-                    };
 
                     var args_nodes = std.ArrayList(ast.Node).init(self.allocator);
                     defer args_nodes.deinit();
@@ -764,21 +1127,67 @@ pub const TranspileProcess = struct {
                         try self.flatten_call_args(right.*, &args_nodes);
                     }
 
-                    if (args_nodes.items.len != sig.args.len) {
-                        self.report_type_error(node, "function '{s}' expects {d} args, got {d}", .{ fname, sig.args.len, args_nodes.items.len });
-                        return TranspileError.WrongArgCount;
-                    }
-
-                    for (args_nodes.items, 0..) |arg_node, idx| {
-                        const actual = try self.infer_expr_type(arg_node, env, fns);
-                        const expected = sig.args[idx];
-                        if (expected.base != .Unknown and actual.base != .Unknown and !can_implicit_coerce(expected, actual)) {
-                            self.report_type_error(node, "type mismatch in call to '{s}' argument {d}", .{ fname, idx + 1 });
-                            return TranspileError.TypeMismatch;
+                    if (maybe_sig) |sig| {
+                        // Function call.
+                        if (args_nodes.items.len != sig.args.len) {
+                            const fname = callee.data.?.sval.items;
+                            self.report_type_error(node, "function '{s}' expects {d} args, got {d}", .{ fname, sig.args.len, args_nodes.items.len });
+                            return TranspileError.WrongArgCount;
+                        }
+                        for (args_nodes.items, 0..) |arg_node, idx| {
+                            const actual = try self.infer_expr_type(arg_node, env, fns);
+                            const expected = sig.args[idx];
+                            if (is_known_type(expected) and is_known_type(actual) and !(try self.can_implicit_coerce(expected, actual))) {
+                                const fname = callee.data.?.sval.items;
+                                self.report_type_error(node, "type mismatch in call to '{s}' argument {d}", .{ fname, idx + 1 });
+                                return TranspileError.TypeMismatch;
+                            }
+                        }
+                    } else if (method_sig) |msig| {
+                        // Quirk method call.
+                        const expected_args = msig.args.items();
+                        if (args_nodes.items.len != expected_args.len) {
+                            self.report_type_error(node, "method '{s}' expects {d} args, got {d}", .{ msig.name.items, expected_args.len, args_nodes.items.len });
+                            return TranspileError.WrongArgCount;
+                        }
+                        for (args_nodes.items, 0..) |arg_node, idx| {
+                            const actual = try self.infer_expr_type(arg_node, env, fns);
+                            const expected = type_from_dtype(expected_args[idx].dtype);
+                            if (is_known_type(expected) and is_known_type(actual) and !(try self.can_implicit_coerce(expected, actual))) {
+                                self.report_type_error(node, "type mismatch in call to method '{s}' argument {d}", .{ msig.name.items, idx + 1 });
+                                return TranspileError.TypeMismatch;
+                            }
                         }
                     }
 
-                    return sig.rtype;
+                    return call_rtype;
+                }
+
+                if (mem.eql(u8, op, ".")) {
+                    const left = exp.left orelse return .{ .base = .Unknown };
+                    const right = exp.right orelse return .{ .base = .Unknown };
+                    if (right.type != .Identifier or right.data == null) {
+                        self.report_type_error(node, "field access requires an identifier", .{});
+                        return TranspileError.TypeMismatch;
+                    }
+
+                    const lt = try self.infer_expr_type(left.*, env, fns);
+                    if (!is_user_named_type(lt)) {
+                        self.report_type_error(node, "field access requires a compound-typed value", .{});
+                        return TranspileError.TypeMismatch;
+                    }
+
+                    if (lt.pointer_depth > 1) {
+                        self.report_type_error(node, "field access supports at most one pointer indirection", .{});
+                        return TranspileError.TypeMismatch;
+                    }
+
+                    const field_name = right.data.?.sval.items;
+                    const fdt = self.lookup_compound_field(lt.name.?, field_name) orelse {
+                        self.report_type_error(node, "type '{s}' has no field '{s}'", .{ lt.name.?, field_name });
+                        return TranspileError.TypeMismatch;
+                    };
+                    return type_from_dtype(fdt);
                 }
 
                 if (mem.eql(u8, op, ",")) {
@@ -836,7 +1245,7 @@ pub const TranspileProcess = struct {
                         return lt;
                     }
 
-                    if (lt.base != .Unknown and rt.base != .Unknown and !can_implicit_coerce(lt, rt)) {
+                    if (is_known_type(lt) and is_known_type(rt) and !(try self.can_implicit_coerce(lt, rt))) {
                         self.report_type_error(node, "type mismatch in assignment", .{});
                         return TranspileError.TypeMismatch;
                     }
@@ -871,7 +1280,7 @@ pub const TranspileProcess = struct {
                 }
 
                 if (mem.eql(u8, op, "==") or mem.eql(u8, op, "!=")) {
-                    if (l.base != .Unknown and r.base != .Unknown and !can_compare_or_match(l, r)) {
+                    if (is_known_type(l) and is_known_type(r) and !can_compare_or_match(l, r)) {
                         self.report_type_error(node, "equality '{s}' expects both sides to have the same type", .{op});
                         return TranspileError.TypeMismatch;
                     }
@@ -917,7 +1326,7 @@ pub const TranspileProcess = struct {
                     try env.put_current(name, vtype);
                     if (v.val) |val| {
                         const init_t = try self.infer_expr_type(val.*, env, fns);
-                        if (vtype.base != .Unknown and init_t.base != .Unknown and !can_implicit_coerce(vtype, init_t)) {
+                        if (is_known_type(vtype) and is_known_type(init_t) and !(try self.can_implicit_coerce(vtype, init_t))) {
                             self.report_type_error(stmt, "type mismatch in initialization of '{s}'", .{name});
                             return TranspileError.TypeMismatch;
                         }
@@ -937,7 +1346,7 @@ pub const TranspileProcess = struct {
                         }
                         const rv = stmt.node_variant.?.statement.return_stmt;
                         const rt = try self.infer_expr_type(rv.*, env, fns);
-                        if (rt.base != .Unknown and !can_implicit_coerce(fn_rtype, rt)) {
+                        if (is_known_type(fn_rtype) and is_known_type(rt) and !(try self.can_implicit_coerce(fn_rtype, rt))) {
                             self.report_type_error(stmt, "return type mismatch", .{});
                             return TranspileError.ReturnTypeMismatch;
                         }
@@ -971,7 +1380,7 @@ pub const TranspileProcess = struct {
                     for (fit.branches.items()) |branch| {
                         if (branch.condition) |cond| {
                             const ct = try self.infer_expr_type(cond.*, env, fns);
-                            if (target_t.base != .Unknown and ct.base != .Unknown and !can_compare_or_match(target_t, ct)) {
+                            if (is_known_type(target_t) and is_known_type(ct) and !can_compare_or_match(target_t, ct)) {
                                 self.report_type_error(stmt, "fit branch condition type must match fit expression type", .{});
                                 return TranspileError.TypeMismatch;
                             }
@@ -1719,6 +2128,57 @@ pub const TranspileProcess = struct {
                     if (function.rtype) |rtype| {
                         rtype.type_str.deinit();
                     }
+                    if (function.name) |name| {
+                        name.deinit();
+                    }
+                },
+                .compound => |c| {
+                    c.name.deinit();
+                    for (c.fields.items()) |f| {
+                        f.name.deinit();
+                        f.dtype.type_str.deinit();
+                        if (f.dtype.array) |array| {
+                            if (!array.brackets.is_empty()) {
+                                for (array.brackets.items()) |bracket| {
+                                    self.deinit_node(bracket);
+                                }
+                            }
+                            array.brackets.deinit();
+                        }
+                        allocator.destroy(f.dtype);
+                    }
+                    c.fields.deinit();
+                },
+                .quirk => |q| {
+                    q.name.deinit();
+                    for (q.methods.items()) |m| {
+                        m.name.deinit();
+                        m.rtype.type_str.deinit();
+                        for (m.args.items()) |a| {
+                            a.name.deinit();
+                            a.dtype.type_str.deinit();
+                            if (a.dtype.array) |array| {
+                                if (!array.brackets.is_empty()) {
+                                    for (array.brackets.items()) |bracket| {
+                                        self.deinit_node(bracket);
+                                    }
+                                }
+                                array.brackets.deinit();
+                            }
+                            allocator.destroy(a.dtype);
+                        }
+                        m.args.deinit();
+                    }
+                    q.methods.deinit();
+                },
+                .impl => |im| {
+                    im.type_name.deinit();
+                    im.quirk_name.deinit();
+                    for (im.methods.items()) |m| {
+                        self.deinit_node(m.*);
+                        allocator.destroy(m);
+                    }
+                    im.methods.deinit();
                 },
                 .statement => |statement| {
                     switch (statement) {
@@ -1791,6 +2251,10 @@ pub const TranspileProcess = struct {
     /// Returns:
     /// - This function does not return any value.
     pub fn deinit(self: *Self) void {
+        if (self.type_registry) |*reg| {
+            reg.deinit();
+            self.type_registry = null;
+        }
         self.ifile.close();
         if (self.ofile) |f| {
             f.close();
@@ -1945,6 +2409,17 @@ pub const TranspileProcess = struct {
     fn write_type(self: *Self, data_type: dtype.DataType) TranspileError!void {
         const c_type = map_type_to_c(data_type.type_str.items);
         try self.write(c_type);
+
+        const ptr_depth: usize = if (data_type.pointer_depth > 0) data_type.pointer_depth else blk: {
+            if (data_type.flags != null and data_type.flags.?.is_pointer) break :blk 1;
+            break :blk 0;
+        };
+        if (ptr_depth > 0) {
+            var i: usize = 0;
+            while (i < ptr_depth) : (i += 1) {
+                try self.write("*");
+            }
+        }
         // TODO: Handle array types
         // if (data_type.array) |array| {
         //     for (array.brackets.items()) |bracket| {
@@ -1953,6 +2428,382 @@ pub const TranspileProcess = struct {
         //         try self.write("]");
         //     }
         // }
+    }
+
+    fn c_ident_sanitize(self: *Self, raw: []const u8) TranspileError![]const u8 {
+        var out = std.ArrayList(u8).init(self.allocator);
+        errdefer out.deinit();
+        for (raw) |c| {
+            if ((c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or (c >= '0' and c <= '9') or c == '_') {
+                out.append(c) catch return TranspileError.MemoryAllocationFailed;
+            } else {
+                out.append('_') catch return TranspileError.MemoryAllocationFailed;
+            }
+        }
+        return out.toOwnedSlice() catch return TranspileError.MemoryAllocationFailed;
+    }
+
+    fn quirk_sig_hash(sig: []const u8) u64 {
+        return std.hash.Wyhash.hash(0, sig);
+    }
+
+    const QuirkCNames = struct {
+        quirk: [64]u8,
+        quirk_len: usize,
+        vtable: [72]u8,
+        vtable_len: usize,
+    };
+
+    fn write_quirk_c_names(sig: []const u8) TranspileError!QuirkCNames {
+        const h = quirk_sig_hash(sig);
+        var out: QuirkCNames = undefined;
+        out.quirk_len = (std.fmt.bufPrint(&out.quirk, "__fun_quirk_{x}", .{h}) catch unreachable).len;
+        out.vtable_len = (std.fmt.bufPrint(&out.vtable, "__fun_quirk_{x}_vtable", .{h}) catch unreachable).len;
+        return out;
+    }
+
+    fn root_registry(self: *Self) ?*TypeRegistry {
+        const root = self.get_root();
+        if (root.type_registry) |*reg| return reg;
+        return null;
+    }
+
+    fn is_quirk_name(self: *Self, name: []const u8) bool {
+        const reg = self.root_registry() orelse return false;
+        return reg.quirk_sig_by_name.contains(name);
+    }
+
+    fn identifier_declared_dtype(self: *Self, ident: []const u8) ?*const dtype.DataType {
+        const ent = self.get_scope_entity(ident) orelse return null;
+        const ent_node = ent.node orelse return null;
+        if (ent_node.type != .Variable or ent_node.node_variant == null) return null;
+        return ent_node.node_variant.?.variable.type;
+    }
+
+    fn identifier_is_quirk_typed(self: *Self, ident: []const u8) bool {
+        const dt = self.identifier_declared_dtype(ident) orelse return false;
+        if (dt.type != .Unknown) return false;
+        return self.is_quirk_name(dt.type_str.items);
+    }
+
+    fn expr_pointer_depth_from_scope(self: *Self, node: ast.Node) usize {
+        switch (node.type) {
+            .Identifier => {
+                if (node.data == null) return 0;
+                const name = node.data.?.sval.items;
+                const ent = self.get_scope_entity(name) orelse return 0;
+                const ent_node = ent.node orelse return 0;
+                if (ent_node.type != .Variable or ent_node.node_variant == null) return 0;
+                return ent_node.node_variant.?.variable.type.pointer_depth;
+            },
+            .Unary => {
+                const u = node.node_variant.?.unary;
+                const base = self.expr_pointer_depth_from_scope(u.operand.*);
+                if (u.indirection) |ind| {
+                    if (base < ind.depth) return 0;
+                    return base - ind.depth;
+                }
+                if (mem.eql(u8, u.op, "&")) return base + 1;
+                return base;
+            },
+            else => return 0,
+        }
+    }
+
+    fn expr_named_pointee_from_scope(self: *Self, node: ast.Node) ?[]const u8 {
+        // Returns type name `T` if expression is a `T*` (pointer_depth == 1).
+        switch (node.type) {
+            .Identifier => {
+                if (node.data == null) return null;
+                const name = node.data.?.sval.items;
+                const ent = self.get_scope_entity(name) orelse return null;
+                const ent_node = ent.node orelse return null;
+                if (ent_node.type != .Variable or ent_node.node_variant == null) return null;
+                const dt = ent_node.node_variant.?.variable.type;
+                if (dt.pointer_depth != 1 or dt.type != .Unknown) return null;
+                return dt.type_str.items;
+            },
+            .Unary => {
+                const u = node.node_variant.?.unary;
+                if (mem.eql(u8, u.op, "&")) {
+                    // &x => pointer to x's declared type
+                    const op = u.operand.*;
+                    if (op.type != .Identifier or op.data == null) return null;
+                    const name = op.data.?.sval.items;
+                    const ent = self.get_scope_entity(name) orelse return null;
+                    const ent_node = ent.node orelse return null;
+                    if (ent_node.type != .Variable or ent_node.node_variant == null) return null;
+                    const dt = ent_node.node_variant.?.variable.type;
+                    if (dt.type != .Unknown) return null;
+                    return dt.type_str.items;
+                }
+                return null;
+            },
+            else => return null,
+        }
+    }
+
+    fn emit_user_types_and_vtables(self: *Self) TranspileError!void {
+        if (self.did_emit_user_types) return;
+        self.did_emit_user_types = true;
+
+        const reg = self.root_registry() orelse return;
+
+        try self.write("// --- User types ---\n\n");
+
+        // Compounds
+        var c_it = reg.compounds_by_name.iterator();
+        while (c_it.next()) |entry| {
+            const cnode = entry.value_ptr.*;
+            if (cnode.node_variant == null) continue;
+            const c = cnode.node_variant.?.compound;
+
+            try self.write("typedef struct ");
+            try self.write(c.name.items);
+            try self.write(" {\n");
+
+            for (c.fields.items()) |f| {
+                try self.write("  ");
+                try self.write_type(f.dtype.*);
+                try self.write(" ");
+                try self.write(f.name.items);
+
+                if (f.dtype.flags != null and f.dtype.flags.?.is_array) {
+                    if (f.dtype.array) |array| {
+                        if (!array.brackets.is_empty()) {
+                            for (array.brackets.items()) |bracket_node| {
+                                try self.write("[");
+                                if (bracket_node.type == .Bracket) {
+                                    try self.transpile_node(bracket_node.node_variant.?.bracket.inner.*);
+                                } else {
+                                    try self.transpile_node(bracket_node);
+                                }
+                                try self.write("]");
+                            }
+                        } else {
+                            try self.write("[]");
+                        }
+                    } else {
+                        try self.write("[]");
+                    }
+                }
+                try self.write(";\n");
+            }
+            try self.write("} ");
+            try self.write(c.name.items);
+            try self.write(";\n\n");
+        }
+
+        // Quirk canonical structs per signature
+        var q_it = reg.quirks_by_sig.iterator();
+        while (q_it.next()) |entry| {
+            const sig = entry.key_ptr.*;
+            const qnode = entry.value_ptr.*;
+            if (qnode.node_variant == null) continue;
+            const q = qnode.node_variant.?.quirk;
+
+            const names = try write_quirk_c_names(sig);
+            const quirk_c = names.quirk[0..names.quirk_len];
+            const vtable_c = names.vtable[0..names.vtable_len];
+
+            // Vtable type
+            try self.write("typedef struct ");
+            try self.write(vtable_c);
+            try self.write(" {\n");
+            for (q.methods.items()) |m| {
+                try self.write("  ");
+                try self.write_type(m.rtype);
+                try self.write(" (*");
+                try self.write(m.name.items);
+                try self.write(")(void* self");
+                for (m.args.items(), 0..) |a, i| {
+                    _ = i;
+                    try self.write(", ");
+                    try self.write_type(a.dtype.*);
+                }
+                try self.write(");\n");
+            }
+            try self.write("} ");
+            try self.write(vtable_c);
+            try self.write(";\n\n");
+
+            // Quirk object type
+            try self.write("typedef struct ");
+            try self.write(quirk_c);
+            try self.write(" {\n");
+            try self.write("  void* self;\n");
+            try self.write("  const ");
+            try self.write(vtable_c);
+            try self.write("* vtable;\n");
+            try self.write("} ");
+            try self.write(quirk_c);
+            try self.write(";\n\n");
+        }
+
+        // Quirk name aliases
+        var qn_it = reg.quirk_sig_by_name.iterator();
+        while (qn_it.next()) |entry| {
+            const qname = entry.key_ptr.*;
+            const sig = entry.value_ptr.*;
+            const names = try write_quirk_c_names(sig);
+            const quirk_c = names.quirk[0..names.quirk_len];
+            try self.write("typedef ");
+            try self.write(quirk_c);
+            try self.write(" ");
+            try self.write(qname);
+            try self.write(";\n");
+        }
+        try self.write("\n");
+
+        // Impl wrappers/vtables/coercions
+        try self.write("// --- Quirk impl vtables ---\n\n");
+        var impl_it = reg.impls_by_key.iterator();
+        while (impl_it.next()) |entry| {
+            const impl_node = entry.value_ptr.*;
+            if (impl_node.node_variant == null) continue;
+            const im = impl_node.node_variant.?.impl;
+            const type_name = im.type_name.items;
+            const quirk_name = im.quirk_name.items;
+            const sig = reg.quirk_sig_by_name.get(quirk_name) orelse continue;
+            const qnode = reg.quirks_by_sig.get(sig) orelse continue;
+            if (qnode.node_variant == null) continue;
+            const q = qnode.node_variant.?.quirk;
+
+            const names = try write_quirk_c_names(sig);
+            const quirk_c = names.quirk[0..names.quirk_len];
+            const vtable_c = names.vtable[0..names.vtable_len];
+
+            const type_s = try self.c_ident_sanitize(type_name);
+            defer self.allocator.free(type_s);
+
+            var vtbl_buf: [96]u8 = undefined;
+            const vtbl_name = (std.fmt.bufPrint(&vtbl_buf, "__fun_impl_{s}_{x}_vtable", .{ type_s, quirk_sig_hash(sig) }) catch unreachable);
+
+            var coerce_buf: [96]u8 = undefined;
+            const coerce_name = (std.fmt.bufPrint(&coerce_buf, "__fun_coerce_{s}_{x}", .{ type_s, quirk_sig_hash(sig) }) catch unreachable);
+
+            // Forward declare generated impl methods so wrappers can call them.
+            for (im.methods.items()) |m| {
+                if (m.type != .Function or m.node_variant == null) continue;
+                const fnv = m.node_variant.?.function;
+                if (fnv.name == null) continue;
+                if (fnv.rtype) |rt| {
+                    try self.write_type(rt);
+                } else {
+                    try self.write("void");
+                }
+                try self.write(" ");
+                try self.write(fnv.name.?.items);
+                try self.write("(");
+                self.in_function_params = true;
+                if (fnv.args) |args| {
+                    for (args.items(), 0..) |arg, i| {
+                        if (i > 0) try self.write(", ");
+                        try self.transpile_node(arg.*);
+                    }
+                }
+                self.in_function_params = false;
+                try self.write(");\n");
+            }
+            try self.write("\n");
+
+            // Emit method bodies.
+            for (im.methods.items()) |m| {
+                if (m.type != .Function or m.node_variant == null) continue;
+                const fnv = m.node_variant.?.function;
+                if (fnv.body == null) continue;
+                try self.transpile_node(m.*);
+                try self.write("\n\n");
+            }
+
+            // Wrappers with `void* self` to match vtable signature.
+            for (q.methods.items()) |m| {
+                // Find the generated method function name by suffix match.
+                var impl_fn_name: ?[]const u8 = null;
+                for (im.methods.items()) |fm| {
+                    if (fm.type != .Function or fm.node_variant == null) continue;
+                    const fnv = fm.node_variant.?.function;
+                    if (fnv.name == null) continue;
+                    const n = fnv.name.?.items;
+                    var suf_buf: [128]u8 = undefined;
+                    const suf = (std.fmt.bufPrint(&suf_buf, "__{s}", .{m.name.items}) catch unreachable);
+                    if (mem.endsWith(u8, n, suf)) {
+                        impl_fn_name = n;
+                        break;
+                    }
+                }
+                if (impl_fn_name == null) continue;
+
+                const m_s = try self.c_ident_sanitize(m.name.items);
+                defer self.allocator.free(m_s);
+                var wrap_buf: [128]u8 = undefined;
+                const wrap_name = (std.fmt.bufPrint(&wrap_buf, "__fun_wrap_{s}_{x}_{s}", .{ type_s, quirk_sig_hash(sig), m_s }) catch unreachable);
+
+                try self.write("static ");
+                try self.write_type(m.rtype);
+                try self.write(" ");
+                try self.write(wrap_name);
+                try self.write("(void* self");
+                for (m.args.items(), 0..) |a, i| {
+                    try self.write(", ");
+                    try self.write_type(a.dtype.*);
+                    var an: [16]u8 = undefined;
+                    const aname = (std.fmt.bufPrint(&an, " a{d}", .{i}) catch unreachable);
+                    try self.write(aname);
+                }
+                try self.write(") {\n");
+
+                try self.write("  ");
+                if (m.rtype.type != .Void) {
+                    try self.write("return ");
+                }
+                try self.write(impl_fn_name.?);
+                try self.write("((");
+                try self.write(type_name);
+                try self.write("*)self");
+                for (m.args.items(), 0..) |_, i| {
+                    var an2: [16]u8 = undefined;
+                    const aname2 = (std.fmt.bufPrint(&an2, ", a{d}", .{i}) catch unreachable);
+                    try self.write(aname2);
+                }
+                try self.write(");\n");
+                try self.write("}\n\n");
+            }
+
+            // Vtable instance
+            try self.write("static const ");
+            try self.write(vtable_c);
+            try self.write(" ");
+            try self.write(vtbl_name);
+            try self.write(" = {\n");
+            for (q.methods.items()) |m| {
+                const m_s = try self.c_ident_sanitize(m.name.items);
+                defer self.allocator.free(m_s);
+                var wrap_buf2: [128]u8 = undefined;
+                const wrap_name2 = (std.fmt.bufPrint(&wrap_buf2, "__fun_wrap_{s}_{x}_{s}", .{ type_s, quirk_sig_hash(sig), m_s }) catch unreachable);
+                try self.write("  .");
+                try self.write(m.name.items);
+                try self.write(" = ");
+                try self.write(wrap_name2);
+                try self.write(",\n");
+            }
+            try self.write("};\n\n");
+
+            // Coercion helper
+            try self.write("static inline ");
+            try self.write(quirk_c);
+            try self.write(" ");
+            try self.write(coerce_name);
+            try self.write("(");
+            try self.write(type_name);
+            try self.write("* self) {\n");
+            try self.write("  return (");
+            try self.write(quirk_c);
+            try self.write("){ .self = self, .vtable = &");
+            try self.write(vtbl_name);
+            try self.write(" };\n");
+            try self.write("}\n\n");
+        }
     }
 
     /// Transpiles all nodes in the AST to C code
@@ -1991,11 +2842,19 @@ pub const TranspileProcess = struct {
             try self.process_import(self.nodes.items()[i]);
         }
 
+        // Collect user-defined type declarations across imports before typechecking.
+        try self.collect_type_registry_all();
+
         // Type check after imports are parsed (so imported signatures are available).
         try self.typecheck_all();
 
         // Write standard library includes and prelude
         try self.transpile_prelude();
+
+        // Emit user-defined types (compounds/quirks) and all impl vtables once at the root.
+        if (!self.is_importing) {
+            try self.emit_user_types_and_vtables();
+        }
 
         // Output content from child imports recursively
         if (!self.is_importing) {
@@ -2005,6 +2864,7 @@ pub const TranspileProcess = struct {
         // Now output the main file content
         for (self.nodes.items()) |node| {
             if (node.type != .Import) { // Skip import nodes as they've been processed
+                if (node.type == .Compound or node.type == .Quirk) continue;
                 try self.transpile_node(node);
                 try self.write("\n\n");
             }
@@ -2020,6 +2880,7 @@ pub const TranspileProcess = struct {
             // Then, transpile the child's own nodes (excluding imports and main functions)
             for (child.nodes.items()) |node| {
                 if (node.type != .Import) {
+                    if (node.type == .Compound or node.type == .Quirk) continue;
                     // Skip main functions in imported modules
                     if (node.type == .Function and node.node_variant != null) {
                         const function = node.node_variant.?.function;
@@ -2049,6 +2910,45 @@ pub const TranspileProcess = struct {
             .Expression => {
                 const exp = node.node_variant.?.exp;
                 if (mem.eql(u8, exp.op, "()")) {
+                    // Quirk method call: `q.method(...)` emits `q.vtable->method(q.self, ...)`.
+                    if (exp.left) |left| {
+                        if (left.type == .Expression and left.node_variant != null and mem.eql(u8, left.node_variant.?.exp.op, ".")) {
+                            const dot = left.node_variant.?.exp;
+                            const recv = dot.left orelse null;
+                            const member = dot.right orelse null;
+                            if (recv != null and member != null and member.?.type == .Identifier and member.?.data != null) {
+                                // Only special-case when receiver is a quirk-typed identifier.
+                                if (recv.?.type == .Identifier and recv.?.data != null and self.identifier_is_quirk_typed(recv.?.data.?.sval.items)) {
+                                    const mname = member.?.data.?.sval.items;
+                                    try self.write("(");
+                                    try self.transpile_node(recv.?.*);
+                                    try self.write(".vtable->");
+                                    try self.write(mname);
+                                    try self.write("(");
+                                    try self.transpile_node(recv.?.*);
+                                    try self.write(".self");
+
+                                    // Append call args.
+                                    if (exp.right) |right| {
+                                        // Right is an ExpressionParenthesis node.
+                                        const inner = if (right.type == .ExpressionParenthesis and right.node_variant != null)
+                                            right.node_variant.?.paren.exp.*
+                                        else
+                                            right.*;
+                                        if (inner.type != .Blank) {
+                                            // Render arg expression(s) as a comma list.
+                                            try self.write(", ");
+                                            try self.transpile_node(inner);
+                                        }
+                                    }
+
+                                    try self.write(")");
+                                    try self.write(")");
+                                    return;
+                                }
+                            }
+                        }
+                    }
                     if (exp.left) |left| {
                         try self.transpile_node(left.*);
                         try self.write("(");
@@ -2078,6 +2978,55 @@ pub const TranspileProcess = struct {
                         }
                     }
                     try self.write("]");
+                } else if (mem.eql(u8, exp.op, ".")) {
+                    const left = exp.left orelse return;
+                    const right = exp.right orelse return;
+                    try self.transpile_node(left.*);
+                    const pd = self.expr_pointer_depth_from_scope(left.*);
+                    try self.write(if (pd > 0) "->" else ".");
+                    try self.transpile_node(right.*);
+                } else if (mem.eql(u8, exp.op, "=")) {
+                    // If assigning into a quirk-typed variable, coerce `T*` -> quirk when possible.
+                    const left = exp.left orelse return;
+                    const right = exp.right orelse return;
+                    if (left.type == .Identifier and left.data != null) {
+                        const lname = left.data.?.sval.items;
+                        if (self.identifier_is_quirk_typed(lname)) {
+                            const reg = self.root_registry() orelse {
+                                try self.transpile_node(left.*);
+                                try self.write(" = ");
+                                try self.transpile_node(right.*);
+                                return;
+                            };
+                            const ldt = self.identifier_declared_dtype(lname) orelse null;
+                            const expected_sig = if (ldt != null) reg.quirk_sig_by_name.get(ldt.?.type_str.items) else null;
+                            if (expected_sig != null) {
+                                const actual = self.expr_named_pointee_from_scope(right.*);
+                                if (actual != null) {
+                                    const key = std.fmt.allocPrint(self.allocator, "{s}|{s}", .{ actual.?, expected_sig.? }) catch {
+                                        return TranspileError.MemoryAllocationFailed;
+                                    };
+                                    defer self.allocator.free(key);
+                                    if (reg.impls_by_key.contains(key)) {
+                                        const type_s = try self.c_ident_sanitize(actual.?);
+                                        defer self.allocator.free(type_s);
+                                        var coerce_buf: [96]u8 = undefined;
+                                        const coerce_name = (std.fmt.bufPrint(&coerce_buf, "__fun_coerce_{s}_{x}", .{ type_s, quirk_sig_hash(expected_sig.?) }) catch unreachable);
+                                        try self.transpile_node(left.*);
+                                        try self.write(" = ");
+                                        try self.write(coerce_name);
+                                        try self.write("(");
+                                        try self.transpile_node(right.*);
+                                        try self.write(")");
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    try self.transpile_node(left.*);
+                    try self.write(" = ");
+                    try self.transpile_node(right.*);
                 } else if (exp.op.len > 0) {
                     if (exp.left) |left| {
                         try self.transpile_node(left.*);
@@ -2181,6 +3130,38 @@ pub const TranspileProcess = struct {
 
                 if (variable.val) |val| {
                     try self.write(" = ");
+
+                    // Implicit quirk coercion in initializers: `Quirk q = &t;`.
+                    if (variable.type.type == .Unknown and self.is_quirk_name(variable.type.type_str.items)) {
+                        const reg = self.root_registry() orelse {
+                            try self.transpile_node(val.*);
+                            if (!self.in_function_params) try self.write(";");
+                            return;
+                        };
+                        const sig = reg.quirk_sig_by_name.get(variable.type.type_str.items) orelse null;
+                        if (sig != null) {
+                            const actual = self.expr_named_pointee_from_scope(val.*);
+                            if (actual != null) {
+                                const key = std.fmt.allocPrint(self.allocator, "{s}|{s}", .{ actual.?, sig.? }) catch {
+                                    return TranspileError.MemoryAllocationFailed;
+                                };
+                                defer self.allocator.free(key);
+                                if (reg.impls_by_key.contains(key)) {
+                                    const type_s = try self.c_ident_sanitize(actual.?);
+                                    defer self.allocator.free(type_s);
+                                    var coerce_buf: [96]u8 = undefined;
+                                    const coerce_name = (std.fmt.bufPrint(&coerce_buf, "__fun_coerce_{s}_{x}", .{ type_s, quirk_sig_hash(sig.?) }) catch unreachable);
+                                    try self.write(coerce_name);
+                                    try self.write("(");
+                                    try self.transpile_node(val.*);
+                                    try self.write(")");
+                                    if (!self.in_function_params) try self.write(";");
+                                    return;
+                                }
+                            }
+                        }
+                    }
+
                     if (val.type == .String) {
                         try self.write("\"");
                         try self.write(val.data.?.sval.items);

--- a/modules/parser/parser.zig
+++ b/modules/parser/parser.zig
@@ -265,6 +265,32 @@ pub const ParseProcess = struct {
         return peek_token;
     }
 
+    /// Peeks at the Nth next non-skippable token without incrementing.
+    ///
+    /// `n = 0` is equivalent to `token_peek_next()`.
+    fn token_peek_n(self: *Self, n: usize) ?token.Token {
+        var idx: isize = self.transpile_proc.tokens.pindex;
+        var seen: usize = 0;
+        while (true) {
+            const t = self.transpile_proc.tokens.at(@intCast(idx)) orelse return null;
+            if (!token.is_nl_or_comment_or_newline_separator(t)) {
+                if (seen == n) return t;
+                seen += 1;
+            }
+            idx += 1;
+        }
+    }
+
+    /// Peeks the previous non-skippable token (relative to the most recently consumed token).
+    fn token_peek_prev(self: *Self) ?token.Token {
+        var idx: isize = @as(isize, @intCast(self.transpile_proc.tokens.pindex)) - 2;
+        while (idx >= 0) : (idx -= 1) {
+            const t = self.transpile_proc.tokens.at(@intCast(idx)) orelse return null;
+            if (!token.is_nl_or_comment_or_newline_separator(t)) return t;
+        }
+        return null;
+    }
+
     /// Retrieves the next token.
     ///
     /// This function peeks at the next token without incrementing the token stream's position.
@@ -336,6 +362,43 @@ pub const ParseProcess = struct {
         if (t.?.type == .Keyword) {
             return try self.parse_keyword(hist);
         }
+
+        // User-defined type variable declarations start with an identifier datatype, e.g.:
+        // `Point p;`, `Point p = ...;`, `Point* p;`, `Point** p = ...;`
+        // Detect `<Identifier> [* ...] <Identifier>` and parse it as a variable declaration.
+        if (t.?.type == .Identifier) {
+            var off: usize = 1;
+            while (true) {
+                const tn = self.token_peek_n(off);
+                if (tn == null) break;
+                if (tn.?.type == .Operator and mem.eql(u8, tn.?.data.sval.items, "*")) {
+                    off += 1;
+                    continue;
+                }
+                break;
+            }
+
+            const t1 = self.token_peek_n(off);
+            if (t1 != null and t1.?.type == .Identifier) {
+                const dt = self.transpile_proc.allocator.create(dtype.DataType) catch |e| {
+                    std.debug.print("Error creating DataType: {}\n", .{e});
+                    return ParseError.MemoryAllocationFailed;
+                };
+                errdefer self.transpile_proc.allocator.destroy(dt);
+                dt.* = dtype.DataType{
+                    .array = null,
+                    .pointer_depth = 0,
+                    .type = .Unknown,
+                    .type_str = std.ArrayList(u8).init(self.transpile_proc.allocator),
+                    .flags = .{},
+                };
+                try self.parse_datatype(dt);
+                try self.parse_variable(dt, hist);
+                try self.expect_sym(';');
+                return;
+            }
+        }
+
         if (t.?.type == .Symbol and token.is_symbol(t, '{')) {
             return try self.parse_body(hist);
         }
@@ -398,7 +461,14 @@ pub const ParseProcess = struct {
         self.parser_current_body = body_node.?;
         try self.expect_sym('{');
         var last_stmt_type: ?ast.NodeType = null;
-        while (!self.next_token_is_symbol('}')) {
+        while (true) {
+            const next_non_skippable = self.token_peek_n(0);
+            if (next_non_skippable == null) {
+                self.transpile_proc.err("unexpected end of file (expected '}}' to close body)", .{});
+                return ParseError.FileReadError;
+            }
+            if (token.is_symbol(next_non_skippable, '}')) break;
+
             var hist_down = utils.History.down(self.transpile_proc.allocator, hist, hist.flags);
             defer hist_down.deinit();
             try self.parse_statement(&hist_down);
@@ -477,6 +547,7 @@ pub const ParseProcess = struct {
                 std.debug.print("Error adding node to list: {s}", .{@errorName(e)});
                 return ParseError.MemoryAllocationFailed;
             };
+            return;
         }
         self.transpile_proc.err("invalid symbol", .{});
         return ParseError.InvalidSymbol;
@@ -547,8 +618,8 @@ pub const ParseProcess = struct {
     /// - Logs an error message if the next token is not a datatype keyword.
     fn parse_datatype(self: *Self, dt: *dtype.DataType) ParseError!void {
         const dt_token = self.token_next();
-        if (dt_token.?.type != .Keyword) {
-            self.transpile_proc.err("expected datatype, got '{?}'", .{dt_token.?.type});
+        if (dt_token == null or (dt_token.?.type != .Keyword and dt_token.?.type != .Identifier)) {
+            self.transpile_proc.err("expected datatype, got '{?}'", .{if (dt_token) |t| t.type else null});
             return ParseError.InvalidDataType;
         }
         const ptr_depth = self.parse_get_pointer_depth();
@@ -556,10 +627,15 @@ pub const ParseProcess = struct {
             dt.*.flags.?.is_pointer = true;
             dt.*.pointer_depth = ptr_depth;
         }
-        dt.*.type = utils.get_datatype_type(dt_token.?.data.sval.items);
-        if (dt.*.type.? == .Unknown) {
-            self.transpile_proc.err("unknown datatype", .{});
-            return ParseError.InvalidDataType;
+        // Builtins use `dt.type`, user-defined types keep `.Unknown` and rely on `type_str`.
+        if (dt_token.?.type == .Keyword and utils.keyword_is_datatype(dt_token.?.data.sval.items)) {
+            dt.*.type = utils.get_datatype_type(dt_token.?.data.sval.items);
+            if (dt.*.type.? == .Unknown) {
+                self.transpile_proc.err("unknown datatype", .{});
+                return ParseError.InvalidDataType;
+            }
+        } else {
+            dt.*.type = .Unknown;
         }
         dt.*.type_str = std.ArrayList(u8).initCapacity(self.transpile_proc.allocator, dt_token.?.data.sval.items.len) catch |e| {
             std.debug.print("Error creating type string: {s}", .{@errorName(e)});
@@ -622,13 +698,18 @@ pub const ParseProcess = struct {
                 }
             },
             .Identifier => {
+                const prev = self.token_peek_prev();
+                const is_member_access = prev != null and prev.?.type == .Operator and mem.eql(u8, prev.?.data.sval.items, ".");
+
                 // `_` is a wildcard identifier (used by `fit` default branches).
                 // It should be accepted even if it's not declared.
                 if (!mem.eql(u8, t.?.data.sval.items, "_")) {
-                    if (self.transpile_proc.get_scope_entity(t.?.data.sval.items) == null) {
-                        if (self.transpile_proc.get_symbol(t.?.data.sval.items) == null and self.transpile_proc.global_symbols.get(t.?.data.sval.items) == null) {
-                            self.transpile_proc.err("unknown identifier '{s}'", .{t.?.data.sval.items});
-                            return ParseError.InvalidIdentifier;
+                    if (!is_member_access) {
+                        if (self.transpile_proc.get_scope_entity(t.?.data.sval.items) == null) {
+                            if (self.transpile_proc.get_symbol(t.?.data.sval.items) == null and self.transpile_proc.global_symbols.get(t.?.data.sval.items) == null) {
+                                self.transpile_proc.err("unknown identifier '{s}'", .{t.?.data.sval.items});
+                                return ParseError.InvalidIdentifier;
+                            }
                         }
                     }
                 }
@@ -1038,7 +1119,6 @@ pub const ParseProcess = struct {
             std.debug.print("Error creating node: {s}", .{@errorName(e)});
             return ParseError.MemoryAllocationFailed;
         };
-        errdefer self.transpile_proc.allocator.destroy(exp_node);
         defer self.transpile_proc.allocator.destroy(exp_node);
         const left = self.transpile_proc.allocator.create(ast.Node) catch |e| {
             std.debug.print("Error creating node: {s}", .{@errorName(e)});
@@ -1156,27 +1236,45 @@ pub const ParseProcess = struct {
     /// Errors:
     /// - Returns an error if any parsing operation fails.
     fn parse_node_shift_children_left(self: *Self, node: *ast.Node) ParseError!void {
-        const right_op = node.*.node_variant.?.exp.right.?.*.node_variant.?.exp.op;
-        var new_exp_left_node = node.*.node_variant.?.exp.left.?.*;
-        var new_exp_right_node = node.*.node_variant.?.exp.right.?.*.node_variant.?.exp.left.?.*;
-        try self.make_expression_node(&new_exp_left_node, &new_exp_right_node, node.*.node_variant.?.exp.op);
-        const new_left_operand = self.node_pop();
-        const new_right_operand = node.*.node_variant.?.exp.right.?.*.node_variant.?.exp.right.?.*;
-        const left = self.transpile_proc.allocator.create(ast.Node) catch |e| {
+        const exp = &node.*.node_variant.?.exp;
+        const right_expr_ptr = exp.right orelse return;
+        if (right_expr_ptr.*.type != .Expression) return;
+
+        const right_exp = &right_expr_ptr.*.node_variant.?.exp;
+        const op2 = right_exp.op;
+
+        const a_ptr = exp.left orelse return;
+        const b_ptr = right_exp.left orelse return;
+        const c_ptr = right_exp.right orelse return;
+
+        const new_left_expr = self.transpile_proc.allocator.create(ast.Node) catch |e| {
             std.debug.print("Error creating node: {s}", .{@errorName(e)});
             return ParseError.MemoryAllocationFailed;
         };
-        errdefer self.transpile_proc.allocator.destroy(left);
-        left.* = new_left_operand.?;
-        const right = self.transpile_proc.allocator.create(ast.Node) catch |e| {
-            std.debug.print("Error creating node: {s}", .{@errorName(e)});
-            return ParseError.MemoryAllocationFailed;
+        errdefer self.transpile_proc.allocator.destroy(new_left_expr);
+        new_left_expr.* = ast.Node{
+            .type = .Expression,
+            .pos = node.*.pos,
+            .binded = null,
+            .node_variant = .{
+                .exp = .{
+                    .left = a_ptr,
+                    .right = b_ptr,
+                    .op = exp.op,
+                },
+            },
         };
-        errdefer self.transpile_proc.allocator.destroy(right);
-        right.* = new_right_operand;
-        node.*.node_variant.?.exp.left = left;
-        node.*.node_variant.?.exp.right = right;
-        node.*.node_variant.?.exp.op = right_op;
+
+        // Rewrite: ((a op1 b) op2 c)
+        exp.left = new_left_expr;
+        exp.right = c_ptr;
+        exp.op = op2;
+
+        // Destroy the old right-expression container, without freeing moved children.
+        right_exp.left = null;
+        right_exp.right = null;
+        self.transpile_proc.deinit_node(right_expr_ptr.*);
+        self.transpile_proc.allocator.destroy(right_expr_ptr);
     }
 
     /// Moves the right-left child of an expression node to the left.
@@ -1191,28 +1289,43 @@ pub const ParseProcess = struct {
     /// Errors:
     /// - Returns an error if any parsing operation fails.
     fn parse_node_move_right_left_to_left(self: *Self, node: *ast.Node) ParseError!void {
-        try self.make_expression_node(
-            node.*.node_variant.?.exp.left.?,
-            node.*.node_variant.?.exp.right.?.*.node_variant.?.exp.left.?,
-            node.*.node_variant.?.exp.op,
-        );
-        const completed_node = self.node_pop();
-        const new_op = node.*.node_variant.?.exp.right.?.*.node_variant.?.exp.op;
-        const left = self.transpile_proc.allocator.create(ast.Node) catch |e| {
+        const exp = &node.*.node_variant.?.exp;
+        const right_expr_ptr = exp.right orelse return;
+        if (right_expr_ptr.*.type != .Expression) return;
+
+        const right_exp = &right_expr_ptr.*.node_variant.?.exp;
+        const op2 = right_exp.op;
+
+        const a_ptr = exp.left orelse return;
+        const b_ptr = right_exp.left orelse return;
+        const c_ptr = right_exp.right orelse return;
+
+        const completed = self.transpile_proc.allocator.create(ast.Node) catch |e| {
             std.debug.print("Error creating node: {s}", .{@errorName(e)});
             return ParseError.MemoryAllocationFailed;
         };
-        errdefer self.transpile_proc.allocator.destroy(left);
-        left.* = completed_node.?;
-        const right = self.transpile_proc.allocator.create(ast.Node) catch |e| {
-            std.debug.print("Error creating node: {s}", .{@errorName(e)});
-            return ParseError.MemoryAllocationFailed;
+        errdefer self.transpile_proc.allocator.destroy(completed);
+        completed.* = ast.Node{
+            .type = .Expression,
+            .pos = node.*.pos,
+            .binded = null,
+            .node_variant = .{
+                .exp = .{
+                    .left = a_ptr,
+                    .right = b_ptr,
+                    .op = exp.op,
+                },
+            },
         };
-        errdefer self.transpile_proc.allocator.destroy(right);
-        right.* = node.*.node_variant.?.exp.right.?.*.node_variant.?.exp.right.?.*;
-        node.*.node_variant.?.exp.left = left;
-        node.*.node_variant.?.exp.right = right;
-        node.*.node_variant.?.exp.op = new_op;
+
+        exp.left = completed;
+        exp.right = c_ptr;
+        exp.op = op2;
+
+        right_exp.left = null;
+        right_exp.right = null;
+        self.transpile_proc.deinit_node(right_expr_ptr.*);
+        self.transpile_proc.allocator.destroy(right_expr_ptr);
     }
 
     /// Reorders an expression node for proper precedence.
@@ -1417,13 +1530,515 @@ pub const ParseProcess = struct {
                 }
                 return try self.parse_expression(hist);
             },
-            .Identifier => try self.parse_identifier(),
+            .Identifier => blk: {
+                // Support user-defined types at statement level: `Point p;`.
+                // If the next token is a known type name and the following token looks like a declaration,
+                // parse it as a variable declaration instead of an identifier expression.
+                const name = t.?.data.sval.items;
+                if (self.transpile_proc.get_symbol(name)) |sym| {
+                    if (sym.type == .Node and sym.data != null) {
+                        const n = sym.data.?.node;
+                        if (n.type == .Compound or n.type == .Quirk) {
+                            const t1 = self.token_peek_n(1);
+                            if (t1 != null and (t1.?.type == .Identifier or (t1.?.type == .Operator and (mem.eql(u8, t1.?.data.sval.items, "*") or mem.eql(u8, t1.?.data.sval.items, "["))))) {
+                                // Parse datatype + variable.
+                                const dt = self.transpile_proc.allocator.create(dtype.DataType) catch |e| {
+                                    std.debug.print("Error creating DataType: {}\n", .{e});
+                                    return ParseError.MemoryAllocationFailed;
+                                };
+                                errdefer self.transpile_proc.allocator.destroy(dt);
+                                dt.* = dtype.DataType{
+                                    .array = null,
+                                    .pointer_depth = 0,
+                                    .type = .Unknown,
+                                    .type_str = std.ArrayList(u8).init(self.transpile_proc.allocator),
+                                    .flags = .{},
+                                };
+                                try self.parse_datatype(dt);
+                                try self.parse_variable(dt, hist);
+                                try self.expect_sym(';');
+                                break :blk true;
+                            }
+                        }
+                    }
+                }
+                break :blk try self.parse_identifier();
+            },
             .Keyword => {
                 try self.parse_keyword(hist);
                 return true;
             },
             .String => try self.parse_string(),
             else => false,
+        };
+    }
+
+    fn parse_compound(self: *Self) ParseError!void {
+        try self.expect_keyword("compound");
+
+        const name_tok = self.token_next();
+        if (name_tok == null or name_tok.?.type != .Identifier) {
+            self.transpile_proc.err("expected identifier after 'compound'", .{});
+            return ParseError.InvalidIdentifier;
+        }
+
+        var name = std.ArrayList(u8).initCapacity(self.transpile_proc.allocator, name_tok.?.data.sval.items.len) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+        errdefer name.deinit();
+        name.appendSlice(name_tok.?.data.sval.items) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+
+        try self.expect_sym('{');
+
+        var fields = utils.Vector(ast.CompoundField).init(self.transpile_proc.allocator);
+        errdefer {
+            for (fields.items()) |f| {
+                f.name.deinit();
+                f.dtype.type_str.deinit();
+                if (f.dtype.array) |array| {
+                    if (!array.brackets.is_empty()) {
+                        for (array.brackets.items()) |bracket| self.transpile_proc.deinit_node(bracket);
+                    }
+                    array.brackets.deinit();
+                }
+                self.transpile_proc.allocator.destroy(f.dtype);
+            }
+            fields.deinit();
+        }
+
+        while (!self.next_token_is_symbol('}')) {
+            // Parse field datatype
+            const dt = self.transpile_proc.allocator.create(dtype.DataType) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+            errdefer self.transpile_proc.allocator.destroy(dt);
+            dt.* = dtype.DataType{
+                .array = null,
+                .pointer_depth = 0,
+                .type = .Unknown,
+                .type_str = std.ArrayList(u8).init(self.transpile_proc.allocator),
+                .flags = .{},
+            };
+            var hist_tmp = utils.History.init(self.transpile_proc.allocator, .{});
+            defer hist_tmp.deinit();
+            try self.parse_datatype(dt);
+            // Allow array brackets after type name in field declarations.
+            if (self.next_token_is_operator("[")) {
+                try self.parse_array_brackets(dt, &hist_tmp);
+            }
+
+            // Parse one or more field names: `dec x, y;`
+            var field_count: usize = 0;
+            while (true) {
+                const field_tok = self.token_next();
+                if (field_tok == null or field_tok.?.type != .Identifier) {
+                    self.transpile_proc.err("expected field name", .{});
+                    return ParseError.InvalidIdentifier;
+                }
+                var fname = std.ArrayList(u8).initCapacity(self.transpile_proc.allocator, field_tok.?.data.sval.items.len) catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+                errdefer fname.deinit();
+                fname.appendSlice(field_tok.?.data.sval.items) catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+
+                // Each field owns its dtype (deep-copy type_str). For multi-name decls,
+                // only allow non-array types (arrays require bracket AST cloning).
+                if (field_count > 0 and dt.array != null) {
+                    self.transpile_proc.err("array fields cannot be declared in a combined list; declare them separately", .{});
+                    return ParseError.InvalidDataType;
+                }
+
+                const field_dt = self.transpile_proc.allocator.create(dtype.DataType) catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+                errdefer self.transpile_proc.allocator.destroy(field_dt);
+                field_dt.* = dt.*;
+                field_dt.*.type_str = std.ArrayList(u8).initCapacity(self.transpile_proc.allocator, dt.type_str.items.len) catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+                field_dt.*.type_str.appendSlice(dt.type_str.items) catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+
+                if (field_count > 0) {
+                    field_dt.*.array = null;
+                }
+
+                fields.push(.{ .name = fname, .dtype = field_dt }) catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+                field_count += 1;
+
+                if (!self.next_token_is_operator(",")) break;
+                _ = self.token_next(); // skip comma
+            }
+
+            // Original dt storage is now unused; destroy it.
+            dt.*.type_str.deinit();
+            self.transpile_proc.allocator.destroy(dt);
+
+            try self.expect_sym(';');
+        }
+        try self.expect_sym('}');
+
+        const node = self.transpile_proc.allocator.create(ast.Node) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+        errdefer {
+            self.transpile_proc.deinit_node(node.*);
+            self.transpile_proc.allocator.destroy(node);
+        }
+        node.* = ast.Node{
+            .type = .Compound,
+            .pos = self.*.transpile_proc.*.pos,
+            .node_variant = .{ .compound = .{ .name = name, .fields = fields } },
+        };
+
+        // Register as a symbol so it can be used as a datatype identifier.
+        try self.transpile_proc.push_symbol(.{ .type = .Node, .name = node.*.node_variant.?.compound.name.items, .data = .{ .node = node.* }, .symbol_table = null });
+
+        self.transpile_proc.nodes.push(node.*) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+        self.transpile_proc.owned_nodes.append(node) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+    }
+
+    fn parse_quirk(self: *Self) ParseError!void {
+        try self.expect_keyword("quirk");
+
+        const name_tok = self.token_next();
+        if (name_tok == null or name_tok.?.type != .Identifier) {
+            self.transpile_proc.err("expected identifier after 'quirk'", .{});
+            return ParseError.InvalidIdentifier;
+        }
+
+        var name = std.ArrayList(u8).initCapacity(self.transpile_proc.allocator, name_tok.?.data.sval.items.len) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+        errdefer name.deinit();
+        name.appendSlice(name_tok.?.data.sval.items) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+
+        try self.expect_sym('{');
+
+        var methods = utils.Vector(ast.QuirkMethodSig).init(self.transpile_proc.allocator);
+        errdefer {
+            for (methods.items()) |m| {
+                m.name.deinit();
+                m.rtype.type_str.deinit();
+                for (m.args.items()) |a| {
+                    a.name.deinit();
+                    a.dtype.type_str.deinit();
+                    if (a.dtype.array) |array| {
+                        if (!array.brackets.is_empty()) {
+                            for (array.brackets.items()) |bracket| self.transpile_proc.deinit_node(bracket);
+                        }
+                        array.brackets.deinit();
+                    }
+                    self.transpile_proc.allocator.destroy(a.dtype);
+                }
+                m.args.deinit();
+            }
+            methods.deinit();
+        }
+
+        while (!self.next_token_is_symbol('}')) {
+            const mname_tok = self.token_next();
+            if (mname_tok == null or mname_tok.?.type != .Identifier) {
+                self.transpile_proc.err("expected method name", .{});
+                return ParseError.InvalidIdentifier;
+            }
+            var mname = std.ArrayList(u8).initCapacity(self.transpile_proc.allocator, mname_tok.?.data.sval.items.len) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+            errdefer mname.deinit();
+            mname.appendSlice(mname_tok.?.data.sval.items) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+
+            try self.expect_op("(");
+
+            var args = utils.Vector(ast.QuirkArg).init(self.transpile_proc.allocator);
+            errdefer args.deinit();
+            while (!self.next_token_is_symbol(')')) {
+                const adt = self.transpile_proc.allocator.create(dtype.DataType) catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+                errdefer self.transpile_proc.allocator.destroy(adt);
+                adt.* = dtype.DataType{ .type_str = std.ArrayList(u8).init(self.transpile_proc.allocator), .flags = .{} };
+                var hist_tmp = utils.History.init(self.transpile_proc.allocator, .{});
+                defer hist_tmp.deinit();
+                try self.parse_datatype(adt);
+                if (self.next_token_is_operator("[")) {
+                    try self.parse_array_brackets(adt, &hist_tmp);
+                }
+
+                const aname_tok = self.token_next();
+                if (aname_tok == null or aname_tok.?.type != .Identifier) {
+                    self.transpile_proc.err("expected argument name", .{});
+                    return ParseError.InvalidIdentifier;
+                }
+                var aname = std.ArrayList(u8).initCapacity(self.transpile_proc.allocator, aname_tok.?.data.sval.items.len) catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+                errdefer aname.deinit();
+                aname.appendSlice(aname_tok.?.data.sval.items) catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+
+                args.push(.{ .name = aname, .dtype = adt }) catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+
+                if (!self.next_token_is_operator(",")) break;
+                _ = self.token_next();
+            }
+            try self.expect_sym(')');
+
+            // Optional return type; default to void.
+            var rtype: dtype.DataType = .{ .type_str = std.ArrayList(u8).init(self.transpile_proc.allocator) };
+            const rtok = self.token_peek_next();
+            if (rtok != null and (rtok.?.type == .Keyword and utils.keyword_is_datatype(rtok.?.data.sval.items)) or rtok.?.type == .Identifier) {
+                try self.parse_datatype(&rtype);
+            } else {
+                rtype.type = .Void;
+                rtype.type_str.appendSlice("void") catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+            }
+
+            try self.expect_sym(';');
+            methods.push(.{ .name = mname, .rtype = rtype, .args = args }) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+        }
+
+        try self.expect_sym('}');
+
+        const node = self.transpile_proc.allocator.create(ast.Node) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+        errdefer {
+            self.transpile_proc.deinit_node(node.*);
+            self.transpile_proc.allocator.destroy(node);
+        }
+        node.* = ast.Node{
+            .type = .Quirk,
+            .pos = self.*.transpile_proc.*.pos,
+            .node_variant = .{ .quirk = .{ .name = name, .methods = methods } },
+        };
+
+        // Register as a symbol so it can be used as a datatype identifier.
+        try self.transpile_proc.push_symbol(.{ .type = .Node, .name = node.*.node_variant.?.quirk.name.items, .data = .{ .node = node.* }, .symbol_table = null });
+
+        self.transpile_proc.nodes.push(node.*) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+        self.transpile_proc.owned_nodes.append(node) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+    }
+
+    fn parse_impl(self: *Self) ParseError!void {
+        try self.expect_keyword("impl");
+        const type_tok = self.token_next();
+        if (type_tok == null or type_tok.?.type != .Identifier) {
+            self.transpile_proc.err("expected type name after 'impl'", .{});
+            return ParseError.InvalidIdentifier;
+        }
+        const quirk_tok = self.token_next();
+        if (quirk_tok == null or quirk_tok.?.type != .Identifier) {
+            self.transpile_proc.err("expected quirk name after type name", .{});
+            return ParseError.InvalidIdentifier;
+        }
+
+        var type_name = std.ArrayList(u8).initCapacity(self.transpile_proc.allocator, type_tok.?.data.sval.items.len) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+        errdefer type_name.deinit();
+        type_name.appendSlice(type_tok.?.data.sval.items) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+        var quirk_name = std.ArrayList(u8).initCapacity(self.transpile_proc.allocator, quirk_tok.?.data.sval.items.len) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+        errdefer quirk_name.deinit();
+        quirk_name.appendSlice(quirk_tok.?.data.sval.items) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+
+        try self.expect_sym('{');
+
+        var methods = utils.Vector(*ast.Node).init(self.transpile_proc.allocator);
+        errdefer {
+            for (methods.items()) |m| {
+                self.transpile_proc.deinit_node(m.*);
+                self.transpile_proc.allocator.destroy(m);
+            }
+            methods.deinit();
+        }
+
+        // Parse methods with syntax similar to functions but without the leading `fun` keyword.
+        // Example: `fun1() void { ... }`
+        while (!self.next_token_is_symbol('}')) {
+            const name_tok = self.token_next();
+            if (name_tok == null or name_tok.?.type != .Identifier) {
+                self.transpile_proc.err("expected method name in impl", .{});
+                return ParseError.InvalidIdentifier;
+            }
+
+            // Build a regular function node with a generated name: `<Type>__<Quirk>__<method>`
+            var fn_node = ast.Node{
+                .type = .Function,
+                .pos = self.*.transpile_proc.*.pos,
+                .node_variant = .{ .function = .{} },
+            };
+
+            const gen_name = std.fmt.allocPrint(self.transpile_proc.allocator, "{s}__{s}__{s}", .{ type_name.items, quirk_name.items, name_tok.?.data.sval.items }) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+            defer self.transpile_proc.allocator.free(gen_name);
+            fn_node.node_variant.?.function.name = std.ArrayList(u8).initCapacity(self.transpile_proc.allocator, gen_name.len) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+            fn_node.node_variant.?.function.name.?.appendSlice(gen_name) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+
+            // Function scope.
+            _ = try self.transpile_proc.new_scope();
+
+            try self.expect_op("(");
+
+            // Implicit `self` arg: `<Type>* self`
+            const self_dt = self.transpile_proc.allocator.create(dtype.DataType) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+            errdefer self.transpile_proc.allocator.destroy(self_dt);
+            self_dt.* = dtype.DataType{
+                .array = null,
+                .pointer_depth = 1,
+                .type = .Unknown,
+                .type_str = std.ArrayList(u8).init(self.transpile_proc.allocator),
+                .flags = .{ .is_pointer = true },
+            };
+            self_dt.type_str.appendSlice(type_name.items) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+
+            var self_name = std.ArrayList(u8).init(self.transpile_proc.allocator);
+            errdefer self_name.deinit();
+            self_name.appendSlice("self") catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+
+            const self_var_ptr = self.transpile_proc.allocator.create(ast.Node) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+            errdefer self.transpile_proc.allocator.destroy(self_var_ptr);
+            self_var_ptr.* = ast.Node{
+                .type = .Variable,
+                .pos = self.*.transpile_proc.*.pos,
+                .node_variant = .{ .variable = .{ .name = self_name, .type = self_dt, .val = null } },
+            };
+            // Register `self` in scope for parsing identifier uses.
+            const self_entity = try self.new_scope_entity(self_var_ptr, .{});
+            self.transpile_proc.owned_scope_entities.append(self_entity) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+            errdefer _ = self.transpile_proc.owned_scope_entities.pop();
+            try self.transpile_proc.push_scope_entity(self_entity);
+
+            var args = utils.Vector(*ast.Node).init(self.transpile_proc.allocator);
+            args.push(self_var_ptr) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+
+            // Parse additional explicit args (datatype name pairs), if any.
+            var hist_args = utils.History.init(self.transpile_proc.allocator, .{});
+            defer hist_args.deinit();
+            while (!self.next_token_is_symbol(')')) {
+                try self.parse_full_variable(&hist_args);
+                const arg_node = self.node_pop();
+                const arg_ptr = self.transpile_proc.allocator.create(ast.Node) catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+                errdefer self.transpile_proc.allocator.destroy(arg_ptr);
+                arg_ptr.* = arg_node.?;
+                args.push(arg_ptr) catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+                if (!self.next_token_is_operator(",")) break;
+                _ = self.token_next();
+            }
+            try self.expect_sym(')');
+
+            fn_node.node_variant.?.function.args = args;
+
+            // Optional return type; default void.
+            var rtype: dtype.DataType = .{ .type_str = std.ArrayList(u8).init(self.transpile_proc.allocator) };
+            const rtok = self.token_peek_next();
+            if (rtok != null and ((rtok.?.type == .Keyword and utils.keyword_is_datatype(rtok.?.data.sval.items)) or rtok.?.type == .Identifier)) {
+                try self.parse_datatype(&rtype);
+                fn_node.node_variant.?.function.rtype = rtype;
+            }
+
+            // Body
+            if (self.next_token_is_symbol('{')) {
+                var hist_body = utils.History.init(self.transpile_proc.allocator, .{ .inside_function_body = true });
+                defer hist_body.deinit();
+                try self.parse_body(&hist_body);
+                const body_node = self.node_pop();
+                const body_ptr = self.transpile_proc.allocator.create(ast.Node) catch {
+                    return ParseError.MemoryAllocationFailed;
+                };
+                errdefer self.transpile_proc.allocator.destroy(body_ptr);
+                body_ptr.* = body_node.?;
+                fn_node.node_variant.?.function.body = body_ptr;
+            } else {
+                try self.expect_sym(';');
+            }
+
+            // End function scope opened above.
+            self.transpile_proc.finish_scope();
+
+            const fn_ptr = self.transpile_proc.allocator.create(ast.Node) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+            errdefer self.transpile_proc.allocator.destroy(fn_ptr);
+            fn_ptr.* = fn_node;
+            methods.push(fn_ptr) catch {
+                return ParseError.MemoryAllocationFailed;
+            };
+        }
+
+        try self.expect_sym('}');
+
+        const node = self.transpile_proc.allocator.create(ast.Node) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+        errdefer {
+            self.transpile_proc.deinit_node(node.*);
+            self.transpile_proc.allocator.destroy(node);
+        }
+        node.* = ast.Node{
+            .type = .Impl,
+            .pos = self.*.transpile_proc.*.pos,
+            .node_variant = .{ .impl = .{ .type_name = type_name, .quirk_name = quirk_name, .methods = methods } },
+        };
+
+        self.transpile_proc.nodes.push(node.*) catch {
+            return ParseError.MemoryAllocationFailed;
+        };
+        self.transpile_proc.owned_nodes.append(node) catch {
+            return ParseError.MemoryAllocationFailed;
         };
     }
 
@@ -1739,7 +2354,18 @@ pub const ParseProcess = struct {
             self.transpile_proc.err("expected indentifier, got '{}'", .{ident_token.?.type});
             return ParseError.InvalidIdentifier;
         }
-        function_node.node_variant.?.function.name = ident_token.?.data.sval;
+        // Function nodes must own their name buffer. Token sval buffers are owned by the token stream
+        // and are deinitialized in `TranspileProcess.deinit()`.
+        var fname = std.ArrayList(u8).initCapacity(self.transpile_proc.allocator, ident_token.?.data.sval.items.len) catch |e| {
+            std.debug.print("Error creating function name: {s}\n", .{@errorName(e)});
+            return ParseError.MemoryAllocationFailed;
+        };
+        errdefer fname.deinit();
+        fname.appendSlice(ident_token.?.data.sval.items) catch |e| {
+            std.debug.print("Error appending to function name: {s}\n", .{@errorName(e)});
+            return ParseError.MemoryAllocationFailed;
+        };
+        function_node.node_variant.?.function.name = fname;
         self.parser_current_function = function_node;
         try self.expect_op("(");
         var hist_args = utils.History.init(self.transpile_proc.allocator, .{});
@@ -2222,6 +2848,12 @@ pub const ParseProcess = struct {
 
         if (mem.eql(u8, "imp", sval)) {
             return try self.parse_import();
+        } else if (mem.eql(u8, "compound", sval)) {
+            return try self.parse_compound();
+        } else if (mem.eql(u8, "quirk", sval)) {
+            return try self.parse_quirk();
+        } else if (mem.eql(u8, "impl", sval)) {
+            return try self.parse_impl();
         } else if (mem.eql(u8, "fun", sval)) {
             return try self.parse_function();
         } else if (mem.eql(u8, "for", sval)) {

--- a/modules/utils/misc.zig
+++ b/modules/utils/misc.zig
@@ -43,7 +43,8 @@ pub fn is_number(c: u8) bool {
 /// - `bool`: `true` if the string is a datatype keyword, otherwise `false`.
 pub fn keyword_is_datatype(str: []const u8) bool {
     // TODO: more to add later
-    return mem.eql(u8, "num", str) or mem.eql(u8, "dec", str) or mem.eql(u8, "str", str) or
+    return mem.eql(u8, "void", str) or
+        mem.eql(u8, "num", str) or mem.eql(u8, "dec", str) or mem.eql(u8, "str", str) or
         mem.eql(u8, "bin", str) or mem.eql(u8, "chr", str);
 }
 
@@ -60,6 +61,8 @@ pub fn keyword_is_datatype(str: []const u8) bool {
 pub fn is_keyword(str: []const u8) bool {
     // TODO: more to add later
     return mem.eql(u8, "imp", str) or mem.eql(u8, "fun", str) or
+        mem.eql(u8, "compound", str) or mem.eql(u8, "quirk", str) or mem.eql(u8, "impl", str) or
+        mem.eql(u8, "void", str) or
         mem.eql(u8, "num", str) or mem.eql(u8, "dec", str) or mem.eql(u8, "str", str) or
         mem.eql(u8, "if", str) or mem.eql(u8, "elif", str) or
         mem.eql(u8, "else", str) or mem.eql(u8, "bin", str) or
@@ -189,6 +192,7 @@ pub fn get_escape_char(c: u8) u8 {
 /// Parameters:
 /// - `dt ( []const u8 )`: The string representation of the data type.
 pub fn get_datatype_type(dt: []const u8) dtype.DataTypeType {
+    if (mem.eql(u8, "void", dt)) return .Void;
     if (mem.eql(u8, "chr", dt)) return .Chr;
     if (mem.eql(u8, "str", dt)) return .Str;
     if (mem.eql(u8, "dec", dt)) return .Dec;

--- a/tests/codegen_test.zig
+++ b/tests/codegen_test.zig
@@ -91,3 +91,111 @@ test "compound assignment transpiles" {
 
     try fs.cwd().deleteFile(ifilepath);
 }
+
+test "compounds + quirks + impl vtables transpile" {
+    const allocator = std.testing.allocator;
+    const ifilepath = "codegen_quirk_vtable.fn";
+
+    const input =
+        "compound Point { num x; num y; }\n" ++
+        "quirk HasX { getX() num; }\n" ++
+        "impl Point HasX {\n" ++
+        "  getX() num { ret self.x; }\n" ++
+        "}\n" ++
+        "fun main() {\n" ++
+        "  Point p;\n" ++
+        "  p.x = 1;\n" ++
+        "  HasX h = &p;\n" ++
+        "  h = &p;\n" ++
+        "  num v = h.getX();\n" ++
+        "}\n";
+
+    const out_owned = try runTranspile(allocator, ifilepath, input);
+    defer allocator.free(out_owned);
+
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "typedef struct Point") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "int x;") != null);
+
+    // Canonical quirk types and impl helpers use hashed names.
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "__fun_quirk_") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "_vtable") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "__fun_coerce_Point_") != null);
+
+    // Coercion and dispatch.
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "HasX h = __fun_coerce_Point_") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "h = __fun_coerce_Point_") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "h.vtable->getX") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "h.self") != null);
+
+    try fs.cwd().deleteFile(ifilepath);
+}
+
+test "pointer field access uses arrow" {
+    const allocator = std.testing.allocator;
+    const ifilepath = "codegen_compound_ptr_field.fn";
+
+    const input =
+        "compound Point { num x; }\n" ++
+        "fun main() {\n" ++
+        "  Point p;\n" ++
+        "  Point* pp = &p;\n" ++
+        "  pp.x = 1;\n" ++
+        "}\n";
+
+    const out_owned = try runTranspile(allocator, ifilepath, input);
+    defer allocator.free(out_owned);
+
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "pp->x") != null);
+
+    try fs.cwd().deleteFile(ifilepath);
+}
+
+fn extractFirstQuirkBaseName(out: []const u8) ?[]const u8 {
+    const start = std.mem.indexOf(u8, out, "typedef struct __fun_quirk_") orelse return null;
+    const sub = out[start..];
+    const base_start = std.mem.indexOf(u8, sub, "__fun_quirk_") orelse return null;
+    const after_prefix = sub[base_start..];
+    const vtable_idx = std.mem.indexOf(u8, after_prefix, "_vtable") orelse return null;
+    return after_prefix[0..vtable_idx];
+}
+
+test "structural quirks share canonical C type" {
+    const allocator = std.testing.allocator;
+    const ifilepath = "codegen_quirk_structural_equiv.fn";
+
+    const input =
+        "compound Point { num x; }\n" ++
+        "quirk Q1 { getX() num; }\n" ++
+        "quirk Q2 { getX() num; }\n" ++
+        "impl Point Q1 { getX() num { ret self.x; } }\n" ++
+        "fun main() {\n" ++
+        "  Point p;\n" ++
+        "  Q1 a = &p;\n" ++
+        "  Q2 b = &p;\n" ++
+        "  num x = a.getX();\n" ++
+        "  num y = b.getX();\n" ++
+        "}\n";
+
+    const out_owned = try runTranspile(allocator, ifilepath, input);
+    defer allocator.free(out_owned);
+
+    const base = extractFirstQuirkBaseName(out_owned) orelse return error.TestExpectedQuirkType;
+
+    const q1_typedef = try std.fmt.allocPrint(allocator, "typedef {s} Q1;", .{base});
+    defer allocator.free(q1_typedef);
+    const q2_typedef = try std.fmt.allocPrint(allocator, "typedef {s} Q2;", .{base});
+    defer allocator.free(q2_typedef);
+
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, q1_typedef) != null);
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, q2_typedef) != null);
+
+    // Both should coerce via the same impl key (signature-canonicalized).
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "Q1 a = __fun_coerce_Point_") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "Q2 b = __fun_coerce_Point_") != null);
+
+    // Both should dispatch through the same canonical vtable/object shape.
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "a.vtable->getX") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out_owned, "b.vtable->getX") != null);
+
+    try fs.cwd().deleteFile(ifilepath);
+}

--- a/tests/typecheck_test.zig
+++ b/tests/typecheck_test.zig
@@ -190,3 +190,78 @@ test "typecheck chr literal and variable" {
 
     try runTranspileExpectOk(std.testing.allocator, "typecheck_chr_ok.fn", input);
 }
+
+test "typecheck compound field access ok" {
+    const input =
+        "compound Point {\n" ++
+        "  num x, y;\n" ++
+        "}\n" ++
+        "fun main() {\n" ++
+        "  Point p;\n" ++
+        "  num a = p.x;\n" ++
+        "  ret;\n" ++
+        "}\n";
+
+    try runTranspileExpectOk(std.testing.allocator, "typecheck_compound_field_ok.fn", input);
+}
+
+test "typecheck compound field missing errors" {
+    const input =
+        "compound Point {\n" ++
+        "  num x;\n" ++
+        "}\n" ++
+        "fun main() {\n" ++
+        "  Point p;\n" ++
+        "  num a = p.y;\n" ++
+        "}\n";
+
+    try runTranspileExpectError(std.testing.allocator, "typecheck_compound_field_missing.fn", input);
+}
+
+test "typecheck quirk method call ok" {
+    const input =
+        "quirk HasX {\n" ++
+        "  getX() num;\n" ++
+        "}\n" ++
+        "fun main() {\n" ++
+        "  HasX h;\n" ++
+        "  num a = h.getX();\n" ++
+        "}\n";
+
+    try runTranspileExpectOk(std.testing.allocator, "typecheck_quirk_method_ok.fn", input);
+}
+
+test "typecheck quirk coercion from impl ok" {
+    const input =
+        "compound Point {\n" ++
+        "  num x;\n" ++
+        "}\n" ++
+        "quirk HasX {\n" ++
+        "  getX() num;\n" ++
+        "}\n" ++
+        "impl Point HasX {\n" ++
+        "  getX() num {\n" ++
+        "    ret self.x;\n" ++
+        "  }\n" ++
+        "}\n" ++
+        "fun main() {\n" ++
+        "  Point p;\n" ++
+        "  HasX h = &p;\n" ++
+        "  num a = h.getX();\n" ++
+        "}\n";
+
+    try runTranspileExpectOk(std.testing.allocator, "typecheck_quirk_coerce_ok.fn", input);
+}
+
+test "typecheck quirk method arg type mismatch errors" {
+    const input =
+        "quirk Q {\n" ++
+        "  foo(num a) void;\n" ++
+        "}\n" ++
+        "fun main() {\n" ++
+        "  Q q;\n" ++
+        "  q.foo(\"hi\");\n" ++
+        "}\n";
+
+    try runTranspileExpectError(std.testing.allocator, "typecheck_quirk_method_arg_mismatch.fn", input);
+}

--- a/tests/utils_test.zig
+++ b/tests/utils_test.zig
@@ -219,7 +219,7 @@ test "Vector peek pointer increment and decrement with peek_decrement flag" {
 test "misc keyword and operator helpers" {
     try std.testing.expect(utils.keyword_is_datatype("num"));
     try std.testing.expect(utils.keyword_is_datatype("str"));
-    try std.testing.expect(!utils.keyword_is_datatype("void"));
+    try std.testing.expect(utils.keyword_is_datatype("void"));
 
     try std.testing.expect(utils.is_keyword("fun"));
     try std.testing.expect(utils.is_keyword("if"));


### PR DESCRIPTION
- Implemented parsing for `compound`, `quirk`, and `impl` constructs in the parser.
- Introduced functions to handle token peeking for non-skippable tokens.
- Enhanced datatype parsing to recognize user-defined types and handle pointer depth.
- Updated the transpilation process to generate appropriate C code for compounds and quirks, including vtable support.
- Added tests for compound field access, quirk method calls, and coercion from implementations.
- Updated utility functions to recognize new keywords and data types, including `void`.