### PR TITLE
DEBUG: isolate codegen_tests_b.fn windows failure (not for merge)

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -50,7 +50,7 @@ jobs:
         timeout-minutes: 20
         run: |
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            FUN_CC=cl FUN_STDLIB_DIR="${{ github.workspace }}/stdlib" ./fun-out/bin/fun.exe test src/tests
+            FUN_CC=cl FUN_STDLIB_DIR="${{ github.workspace }}/stdlib" ./fun-out/bin/fun.exe test src/tests/codegen_tests_b.fn
           else
             export FUN_STDLIB_DIR="$PWD/stdlib"
             ./fun-out/bin/fun test src/tests


### PR DESCRIPTION
Diagnostic-only PR to get an isolated CI log for the windows-native codegen_tests_b.fn failure. Will close without merging.