### PR TITLE
DEBUG bisect: literal-shorthand fix only (not for merge)

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -50,7 +50,7 @@ jobs:
         timeout-minutes: 20
         run: |
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            FUN_CC=cl FUN_STDLIB_DIR="${{ github.workspace }}/stdlib" ./fun-out/bin/fun.exe test src/tests
+            FUN_CC=cl FUN_STDLIB_DIR="${{ github.workspace }}/stdlib" ./fun-out/bin/fun.exe test src/tests/codegen_tests_b.fn
           else
             export FUN_STDLIB_DIR="$PWD/stdlib"
             ./fun-out/bin/fun test src/tests

--- a/src/fls/navigation.fn
+++ b/src/fls/navigation.fn
@@ -494,7 +494,15 @@ pub fun resolve_at(AnalysisCache* cache, Document doc, Vec<Token>* tokens, Token
   // program happens to declare (or nothing at all).
   str literal_type_name = "";
   Vec<str> literal_args;
-  bin in_literal = compound_literal_field_context(tokens, t, &literal_type_name, &literal_args);
+  bin in_literal = compound_literal_field_context(
+    tokens,
+    t,
+    &program.nodes,
+    doc.path,
+    source_line,
+    &literal_type_name,
+    &literal_args
+  );
   if in_literal {
     let field = lookup_field(&program.nodes, literal_type_name, name, literal_args);
     literal_args.free();

--- a/src/fls/symbols.fn
+++ b/src/fls/symbols.fn
@@ -669,17 +669,21 @@ pub fun lookup_field(Vec<Node>* program, str type_name, str field, Vec<str> conc
 // Whether `field_tok` sits at a compound-literal's own `field = value`
 // position (`Box<AsyncCounter>{v = q}`'s own `v`, `.{ v = q }`'s own
 // `v`, or plain `Box{v = q}`'s own `v`), and if so, the literal's own
-// compound name and explicit generic args - "" and empty when the
-// literal is a bare `.{...}` shorthand (its own type comes from
-// context, not resolvable from the tokens alone). Purely token-based,
-// walking backward from `field_tok` to the nearest unmatched `{` and
-// whatever names it, the same style `_infer_type_primary`'s own
-// (forward-facing) compound-literal handling already uses rather than
-// a real AST-position lookup - `CompoundInitField` carries no position
-// of its own to look up by.
+// compound name and explicit generic args. A bare `.{...}` shorthand
+// carries no type of its own in its tokens, so that case resolves it
+// from the surrounding assignment/declaration instead, the same way a
+// bare `.Variant` shorthand resolves its enum from context. Otherwise
+// purely token-based, walking backward from `field_tok` to the nearest
+// unmatched `{` and whatever names it, the same style
+// `_infer_type_primary`'s own (forward-facing) compound-literal
+// handling already uses rather than a real AST-position lookup -
+// `CompoundInitField` carries no position of its own to look up by.
 pub fun compound_literal_field_context(
   Vec<Token>* tokens,
   Token field_tok,
+  Vec<Node>* program,
+  str file,
+  num line,
   str* out_name,
   Vec<str>* out_args
 ) bin {
@@ -754,6 +758,41 @@ pub fun compound_literal_field_context(
   }
   if before_brace.unwrap().type == .Identifier {
     *out_name = token_word(before_brace.unwrap());
+    ret true;
+  }
+  if token_is_operator(before_brace.unwrap(), ".") {
+    // Bare `.{...}` shorthand: resolve its type the same way a bare
+    // `.Variant` shorthand resolves its enum, from whatever it's being
+    // assigned or compared to.
+    num dot_idx = index_of_token(tokens, before_brace.unwrap());
+    num ci = dot_idx - 1;
+    for ci >= 0 && tokens.get(ci).type == .NewLine {
+      ci = ci - 1;
+    }
+    if ci < 0 {
+      ret false;
+    }
+    Token prev = tokens.get(ci);
+    bin is_assign_like = token_is_operator(prev, "=") || token_is_operator(prev, "==") ||
+      token_is_operator(prev, "!=");
+    if !is_assign_like {
+      ret false;
+    }
+    let operand = token_before(tokens, ci);
+    if operand.is_none() {
+      ret false;
+    }
+    Token last = operand.unwrap();
+    let receiver = chain_ending_receiver(tokens, last, token_is_symbol(last, ')'), program, file, line, 0);
+    if equals(receiver.type_name, "") {
+      ret false;
+    }
+    *out_name = receiver.type_name;
+    num gi = 0;
+    for gi < receiver.generic_args.len {
+      out_args.push(receiver.generic_args.get(gi));
+      gi = gi + 1;
+    }
     ret true;
   }
   ret false;

--- a/src/tests/fls_tests.fn
+++ b/src/tests/fls_tests.fn
@@ -5363,3 +5363,26 @@ test "a client that does not understand a skeleton is sent none" {
   assert !contains(out, `"insertTextFormat"`), "expected no snippet";
   assert !contains(out, `"label":"iferr"`), "expected no trigger, which is only its expansion";
 }
+
+test "hover resolves a field name inside a bare '.{...}' compound-literal shorthand" {
+  // `compound_literal_field_context` already resolved a typed literal
+  // (`Node<num>{value = 2}`) and a named one (`Node{value = 2}`), but
+  // fell through for the bare `.{...}` shorthand, whose own type comes
+  // from the surrounding declaration rather than its own tokens.
+  AnalysisCache reads = analysis_cache_new();
+  defer reads.free();
+  Document doc;
+  doc.uri = "file:///literalshorthand.fn";
+  doc.path = "literalshorthand.fn";
+  doc.text = `compound Node<T> {
+  `  T value;
+  `  Node<T>* next;
+  `}
+  `fun main() {
+  `  Node<num> n1 = .{value = 2, next = nil};
+  `}`;
+  doc.version = 1;
+
+  str hovered = hover(&reads, doc, 5, 20);
+  assert contains(hovered, "num value"), "expected the literal's own 'value' field to resolve, generic arg substituted";
+}


### PR DESCRIPTION
Bisection PR, isolates whether the compound-literal shorthand fix alone triggers the windows codegen_tests_b.fn crash.