### PR TITLE
DEBUG bisect: generic-constraint fix only (not for merge)

### DIFF
--- a/fun.toml
+++ b/fun.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fun"
-version = "0.50.3"
+version = "0.50.4"
 
 [[exe]]
 name = "fun"

--- a/src/ast/ast.fn
+++ b/src/ast/ast.fn
@@ -328,6 +328,12 @@ pub compound FunctionNode {
   // (`fun f<T: num | str>` -> [["num"], ["str"]]), parallel to type_params.
   Vec<Vec<str>> type_param_forced_insts;
   bin has_type_param_forced_insts;
+  // Each type param's own declared constraint, index-aligned with
+  // type_params (`fun f<T: num | str>` -> [["num", "str"]]); empty per
+  // param when unconstrained. For display (hover, signatures), unlike
+  // type_param_forced_insts' combined Cartesian product.
+  Vec<Vec<str>> type_param_constraints;
+  bin has_type_param_constraints;
   Vec<Node*> args;
   bin has_args;
   bin is_async;
@@ -346,6 +352,8 @@ pub fun function_node_new() FunctionNode {
   f.has_type_params = false;
   f.type_param_forced_insts.init(0);
   f.has_type_param_forced_insts = false;
+  f.type_param_constraints.init(0);
+  f.has_type_param_constraints = false;
   f.args.init(0);
   f.has_args = false;
   f.is_async = false;
@@ -466,6 +474,10 @@ pub compound CompoundNode {
   bin has_type_params;
   Vec<Vec<str>> type_param_forced_insts;
   bin has_type_param_forced_insts;
+  // Each type param's own declared constraint, index-aligned with
+  // type_params; see FunctionNode's own field of the same name.
+  Vec<Vec<str>> type_param_constraints;
+  bin has_type_param_constraints;
 }
 
 pub fun compound_node_new() CompoundNode {
@@ -476,6 +488,8 @@ pub fun compound_node_new() CompoundNode {
   c.has_type_params = false;
   c.type_param_forced_insts.init(0);
   c.has_type_param_forced_insts = false;
+  c.type_param_constraints.init(0);
+  c.has_type_param_constraints = false;
   ret c;
 }
 
@@ -584,6 +598,10 @@ pub compound ImplNode {
   bin has_type_params;
   Vec<Vec<str>> type_param_forced_insts;
   bin has_type_param_forced_insts;
+  // Each type param's own declared constraint, index-aligned with
+  // type_params; see FunctionNode's own field of the same name.
+  Vec<Vec<str>> type_param_constraints;
+  bin has_type_param_constraints;
   // Bare quirk name (`Iterator`, `To`, ...), even when the `as` clause names
   // a concrete instantiation (`as Iterator<num>`). Absent for a plain impl
   // block (`impl Type { ... }`).
@@ -613,6 +631,8 @@ pub fun impl_node_new() ImplNode {
   i.has_type_params = false;
   i.type_param_forced_insts.init(0);
   i.has_type_param_forced_insts = false;
+  i.type_param_constraints.init(0);
+  i.has_type_param_constraints = false;
   i.quirk_name = "";
   i.has_quirk_name = false;
   i.quirk_concrete_instantiation = "";

--- a/src/fls/symbols.fn
+++ b/src/fls/symbols.fn
@@ -215,7 +215,17 @@ pub fun render_function(FunctionNode f) str {
 // (function, compound, enum, quirk), so a compound/enum/quirk's own
 // hover shows its type params the same way a function's already does,
 // not just "compound Box" with no `<T>` at all.
-fun _append_type_params(StringBuilder* b, bin has_type_params, Vec<str>* type_params) {
+// `type_param_constraints`, when not nil, is index-aligned with
+// `type_params`: each entry's own declared constraint types
+// (`<T: dec | num>` -> `["dec", "num"]` at T's own index), rendered as
+// `T: dec | num` rather than the bare name. nil or an empty entry at a
+// given index renders that param bare, as before.
+fun _append_type_params(
+  StringBuilder* b,
+  bin has_type_params,
+  Vec<str>* type_params,
+  Vec<Vec<str>>* type_param_constraints
+) {
   if !has_type_params || type_params.len == 0 {
     ret;
   }
@@ -226,6 +236,20 @@ fun _append_type_params(StringBuilder* b, bin has_type_params, Vec<str>* type_pa
       b.append(", ");
     }
     b.append(type_params.get(t));
+    if type_param_constraints != nil && t < type_param_constraints.len {
+      let constraint = type_param_constraints.get(t);
+      if constraint.len > 0 {
+        b.append(": ");
+        num ci = 0;
+        for ci < constraint.len {
+          if ci > 0 {
+            b.append(" | ");
+          }
+          b.append(constraint.get(ci));
+          ci = ci + 1;
+        }
+      }
+    }
     t = t + 1;
   }
   b.append(">");
@@ -240,7 +264,7 @@ pub fun render_function_named(FunctionNode f, str name, bin include_fun) str {
     b.append("fun ");
   }
   b.append(name);
-  _append_type_params(&b, f.has_type_params, &f.type_params);
+  _append_type_params(&b, f.has_type_params, &f.type_params, &f.type_param_constraints);
   b.append("(");
   num i = 0;
   for i < f.args.len {
@@ -561,7 +585,7 @@ pub fun lookup_top_level(Vec<Node>* program, str name) Option<Declaration> {
           StringBuilder b = string_builder_init(32);
           b.append("compound ");
           b.append(c.name);
-          _append_type_params(&b, c.has_type_params, &c.type_params);
+          _append_type_params(&b, c.has_type_params, &c.type_params, &c.type_param_constraints);
           ret .Some(_declaration_vis(name, .Compound, b.build(), n.pos, n.flags.is_public));
         }
       }
@@ -570,7 +594,7 @@ pub fun lookup_top_level(Vec<Node>* program, str name) Option<Declaration> {
           StringBuilder b = string_builder_init(32);
           b.append("enum ");
           b.append(e.name);
-          _append_type_params(&b, e.has_type_params, &e.type_params);
+          _append_type_params(&b, e.has_type_params, &e.type_params, nil);
           ret .Some(_declaration_vis(name, .Enum, b.build(), n.pos, n.flags.is_public));
         }
       }
@@ -579,7 +603,7 @@ pub fun lookup_top_level(Vec<Node>* program, str name) Option<Declaration> {
           StringBuilder b = string_builder_init(32);
           b.append("quirk ");
           b.append(q.name);
-          _append_type_params(&b, q.has_type_params, &q.type_params);
+          _append_type_params(&b, q.has_type_params, &q.type_params, nil);
           ret .Some(_declaration_vis(name, .Quirk, b.build(), n.pos, n.flags.is_public));
         }
       }
@@ -4710,7 +4734,7 @@ pub fun _collect_declarations(Vec<Node>* nodes, str file, Vec<Declaration>* out)
         StringBuilder cb = string_builder_init(32);
         cb.append("compound ");
         cb.append(c.name);
-        _append_type_params(&cb, c.has_type_params, &c.type_params);
+        _append_type_params(&cb, c.has_type_params, &c.type_params, &c.type_param_constraints);
         out.push(_declaration_vis(c.name, .Compound, cb.build(), n.pos, n.flags.is_public));
         num f = 0;
         for f < c.fields.len {
@@ -4735,7 +4759,7 @@ pub fun _collect_declarations(Vec<Node>* nodes, str file, Vec<Declaration>* out)
         StringBuilder eb = string_builder_init(32);
         eb.append("enum ");
         eb.append(e.name);
-        _append_type_params(&eb, e.has_type_params, &e.type_params);
+        _append_type_params(&eb, e.has_type_params, &e.type_params, nil);
         out.push(_declaration_vis(e.name, .Enum, eb.build(), n.pos, n.flags.is_public));
         num v = 0;
         for v < e.variants.len {
@@ -4766,7 +4790,7 @@ pub fun _collect_declarations(Vec<Node>* nodes, str file, Vec<Declaration>* out)
         StringBuilder qb = string_builder_init(32);
         qb.append("quirk ");
         qb.append(q.name);
-        _append_type_params(&qb, q.has_type_params, &q.type_params);
+        _append_type_params(&qb, q.has_type_params, &q.type_params, nil);
         out.push(_declaration_vis(q.name, .Quirk, qb.build(), n.pos, n.flags.is_public));
       }
       .Impl(im) -> {

--- a/src/parser/parser.fn
+++ b/src/parser/parser.fn
@@ -542,15 +542,17 @@ impl ParseState {
   // constraint set (e.g. `<T: num | dec, U: a | b>` produces all four
   // `[T, U]` pairings). Constraint names are captured as plain strings,
   // not interpreted here.
-  pub parse_type_params_with_constraints(Vec<str>* out_params, Vec<Vec<str>>* out_forced_insts) Option<ParseErrorKind> {
+  pub parse_type_params_with_constraints(
+    Vec<str>* out_params,
+    Vec<Vec<str>>* out_forced_insts,
+    Vec<Vec<str>>* out_param_constraints
+  ) Option<ParseErrorKind> {
     self.split_angle_opener_token_if_needed();
     if !self.next_token_is_angle_open() {
       ret .None;
     }
     self.token_next(); // consume '<'
 
-    Vec<Vec<str>> param_constraints;
-    param_constraints.init(0);
     bin has_constraints = false;
 
     for true {
@@ -595,7 +597,7 @@ impl ParseState {
           break;
         }
       }
-      param_constraints.push(constraints);
+      out_param_constraints.push(constraints);
 
       if self.next_token_is_operator(",") {
         self.token_next();
@@ -624,7 +626,8 @@ impl ParseState {
       initial.init(0);
       combos.push(initial);
 
-      for pc : param_constraints {
+      Vec<Vec<str>> pc_all = *out_param_constraints;
+      for pc : pc_all {
         Vec<Vec<str>> new_combos;
         new_combos.init(0);
         for existing : combos {
@@ -3385,9 +3388,12 @@ impl Parser {
     type_params.init(0);
     Vec<Vec<str>> type_param_forced_insts;
     type_param_forced_insts.init(0);
+    Vec<Vec<str>> type_param_constraints;
+    type_param_constraints.init(0);
     let tperr = self.state.parse_type_params_with_constraints(
       &type_params,
-      &type_param_forced_insts
+      &type_param_forced_insts,
+      &type_param_constraints
     );
     if tperr.is_some() {
       ret tperr;
@@ -3398,6 +3404,8 @@ impl Parser {
         curtp.has_type_params = type_params.len > 0;
         curtp.type_param_forced_insts = type_param_forced_insts;
         curtp.has_type_param_forced_insts = type_param_forced_insts.len > 0;
+        curtp.type_param_constraints = type_param_constraints;
+        curtp.has_type_param_constraints = type_param_constraints.len > 0;
         fn_node_ptr.kind = .Function(curtp);
       }
       _ -> {}
@@ -5448,9 +5456,12 @@ impl Parser {
     type_params.init(0);
     Vec<Vec<str>> type_param_forced_insts;
     type_param_forced_insts.init(0);
+    Vec<Vec<str>> type_param_constraints;
+    type_param_constraints.init(0);
     let tperr = self.state.parse_type_params_with_constraints(
       &type_params,
-      &type_param_forced_insts
+      &type_param_forced_insts,
+      &type_param_constraints
     );
     if tperr.is_some() {
       ret tperr;
@@ -5534,6 +5545,8 @@ impl Parser {
     cn.has_type_params = type_params.len > 0;
     cn.type_param_forced_insts = type_param_forced_insts;
     cn.has_type_param_forced_insts = type_param_forced_insts.len > 0;
+    cn.type_param_constraints = type_param_constraints;
+    cn.has_type_param_constraints = type_param_constraints.len > 0;
 
     Node node = node_new(.Compound(cn));
     node.pos = name_tok.unwrap().pos;
@@ -5576,7 +5589,13 @@ impl Parser {
     type_params.init(0);
     Vec<Vec<str>> unused_forced_insts;
     unused_forced_insts.init(0);
-    let tperr = self.state.parse_type_params_with_constraints(&type_params, &unused_forced_insts);
+    Vec<Vec<str>> unused_param_constraints;
+    unused_param_constraints.init(0);
+    let tperr = self.state.parse_type_params_with_constraints(
+      &type_params,
+      &unused_forced_insts,
+      &unused_param_constraints
+    );
     if tperr.is_some() {
       ret tperr;
     }
@@ -5739,7 +5758,13 @@ impl Parser {
     type_params.init(0);
     Vec<Vec<str>> unused_forced_insts;
     unused_forced_insts.init(0);
-    let tperr = self.state.parse_type_params_with_constraints(&type_params, &unused_forced_insts);
+    Vec<Vec<str>> unused_param_constraints;
+    unused_param_constraints.init(0);
+    let tperr = self.state.parse_type_params_with_constraints(
+      &type_params,
+      &unused_forced_insts,
+      &unused_param_constraints
+    );
     if tperr.is_some() {
       ret tperr;
     }
@@ -5924,6 +5949,8 @@ impl Parser {
     type_params.init(0);
     Vec<Vec<str>> type_param_forced_insts;
     type_param_forced_insts.init(0);
+    Vec<Vec<str>> type_param_constraints;
+    type_param_constraints.init(0);
     str type_name = base_type_name;
     DataType* impl_concrete_dt = nil;
     bin has_impl_concrete_dt = false;
@@ -5932,7 +5959,8 @@ impl Parser {
       if self.state.impl_generic_args_are_params() {
         let tperr = self.state.parse_type_params_with_constraints(
           &type_params,
-          &type_param_forced_insts
+          &type_param_forced_insts,
+          &type_param_constraints
         );
         if tperr.is_some() {
           ret tperr;
@@ -5952,7 +5980,8 @@ impl Parser {
     } else {
       let tperr = self.state.parse_type_params_with_constraints(
         &type_params,
-        &type_param_forced_insts
+        &type_param_forced_insts,
+        &type_param_constraints
       );
       if tperr.is_some() {
         ret tperr;
@@ -5960,6 +5989,7 @@ impl Parser {
     }
     bin has_type_params = type_params.len > 0;
     bin has_type_param_forced_insts = type_param_forced_insts.len > 0;
+    bin has_type_param_constraints = type_param_constraints.len > 0;
 
     let peek_after_type = self.state.token_peek_next();
 
@@ -6043,6 +6073,8 @@ impl Parser {
     impln.has_type_params = has_type_params;
     impln.type_param_forced_insts = type_param_forced_insts;
     impln.has_type_param_forced_insts = has_type_param_forced_insts;
+    impln.type_param_constraints = type_param_constraints;
+    impln.has_type_param_constraints = has_type_param_constraints;
     impln.quirk_name = quirk_name;
     impln.has_quirk_name = has_quirk_name;
     impln.quirk_concrete_instantiation = quirk_concrete_instantiation;
@@ -6136,9 +6168,12 @@ impl Parser {
     method_type_params.init(0);
     Vec<Vec<str>> method_type_param_forced_insts;
     method_type_param_forced_insts.init(0);
+    Vec<Vec<str>> method_type_param_constraints;
+    method_type_param_constraints.init(0);
     let mtperr = self.state.parse_type_params_with_constraints(
       &method_type_params,
-      &method_type_param_forced_insts
+      &method_type_param_forced_insts,
+      &method_type_param_constraints
     );
     if mtperr.is_some() {
       ret mtperr;
@@ -6149,6 +6184,8 @@ impl Parser {
         curmtp.has_type_params = method_type_params.len > 0;
         curmtp.type_param_forced_insts = method_type_param_forced_insts;
         curmtp.has_type_param_forced_insts = method_type_param_forced_insts.len > 0;
+        curmtp.type_param_constraints = method_type_param_constraints;
+        curmtp.has_type_param_constraints = method_type_param_constraints.len > 0;
         fn_node_ptr.kind = .Function(curmtp);
       }
       _ -> {}

--- a/src/tests/fls_tests.fn
+++ b/src/tests/fls_tests.fn
@@ -5363,3 +5363,42 @@ test "a client that does not understand a skeleton is sent none" {
   assert !contains(out, `"insertTextFormat"`), "expected no snippet";
   assert !contains(out, `"label":"iferr"`), "expected no trigger, which is only its expansion";
 }
+
+test "hover resolves a field name inside a bare '.{...}' compound-literal shorthand" {
+  // `compound_literal_field_context` already resolved a typed literal
+  // (`Node<num>{value = 2}`) and a named one (`Node{value = 2}`), but
+  // fell through for the bare `.{...}` shorthand, whose own type comes
+  // from the surrounding declaration rather than its own tokens.
+  AnalysisCache reads = analysis_cache_new();
+  defer reads.free();
+  Document doc;
+  doc.uri = "file:///literalshorthand.fn";
+  doc.path = "literalshorthand.fn";
+  doc.text = `compound Node<T> {
+  `  T value;
+  `  Node<T>* next;
+  `}
+  `fun main() {
+  `  Node<num> n1 = .{value = 2, next = nil};
+  `}`;
+  doc.version = 1;
+
+  str hovered = hover(&reads, doc, 5, 20);
+  assert contains(hovered, "num value"), "expected the literal's own 'value' field to resolve, generic arg substituted";
+}
+
+test "hover on a generic compound shows each type param's own constraint" {
+  AnalysisCache reads = analysis_cache_new();
+  defer reads.free();
+  Document doc;
+  doc.uri = "file:///constrainedgeneric.fn";
+  doc.path = "constrainedgeneric.fn";
+  doc.text = `compound Node<T: dec | num> {
+  `  T value;
+  `  Node<T>* next;
+  `}`;
+  doc.version = 1;
+
+  str hovered = hover(&reads, doc, 0, 10);
+  assert contains(hovered, "Node<T: dec | num>"), "expected the constraint to render alongside the type param, not just 'T'";
+}


### PR DESCRIPTION
Bisection PR, isolates whether the generic-constraint AST/parser fix alone triggers the windows codegen_tests_b.fn crash.